### PR TITLE
Feature: Security levels

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,8 @@
 	"customizations": {
 		"vscode": {
 			"extensions": [
-				"charliermarsh.ruff"
+				"charliermarsh.ruff",
+				"svelte.svelte-vscode"
 			],
 			"settings": {
 				"python.defaultInterpreterPath": "/workspace/backend/.venv/bin/python",

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -23,6 +23,8 @@ services:
       - postgres_data:/var/lib/postgresql/data
     environment:
       POSTGRES_PASSWORD: postgres
+    ports:
+      - "5432:5432"
 
   redis:
     image: redis

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -19,7 +19,7 @@ python -m poetry install
 # Install Node.js dependencies
 cd /workspace/frontend
 
-npm install -g pnpm@8.9.0
+npm install -g pnpm@9.12.3
 # Set pnpm store directory
 pnpm config set store-dir $HOME/.pnpm-store
 pnpm run setup

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,5 +18,15 @@
             "justMyCode": true,
             "cwd": "${workspaceFolder}/backend"
         },
+        {
+            "name": "Tests: Debug",
+            "consoleName": "Tests: Debug",
+            "type": "debugpy",
+            "request": "launch",
+            "module": "pytest",
+            "jinja": true,
+            "justMyCode": true,
+            "cwd": "${workspaceFolder}/backend"
+        }
     ]
 }

--- a/backend/alembic/versions/68d47ec6a9ed_merge_multiple_heads.py
+++ b/backend/alembic/versions/68d47ec6a9ed_merge_multiple_heads.py
@@ -1,0 +1,21 @@
+"""merge multiple heads
+Revision ID: 68d47ec6a9ed
+Revises: 16ed8ac3ef47, de35b1f40da3
+Create Date: 2025-02-18 08:09:37.729509
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic
+revision = '68d47ec6a9ed'
+down_revision = ('16ed8ac3ef47', 'de35b1f40da3')
+branch_labels = None
+depends_on = None
+
+def upgrade() -> None:
+    pass
+
+def downgrade() -> None:
+    pass

--- a/backend/alembic/versions/de35b1f40da3_create_security_levels_table.py
+++ b/backend/alembic/versions/de35b1f40da3_create_security_levels_table.py
@@ -1,0 +1,104 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+"""create_security_levels_table
+
+Revision ID: de35b1f40da3
+Revises: bd5e20893670
+Create Date: 2025-01-09 13:14:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic
+revision = "de35b1f40da3"
+down_revision = "bd5e20893670"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Create security levels table
+    op.create_table(
+        "security_levels",
+        sa.Column("name", sa.String(), nullable=False),
+        sa.Column("description", sa.String(), nullable=True),
+        sa.Column("value", sa.Integer(), nullable=False),
+        sa.Column(
+            "id",
+            sa.UUID(),
+            server_default=sa.text("gen_random_uuid()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "tenant_id",
+            sa.UUID(),
+            sa.ForeignKey("tenants.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.TIMESTAMP(timezone=True),
+            server_default=sa.text("now()"),
+            nullable=False,
+        ),
+        sa.Column(
+            "deleted_at",
+            sa.TIMESTAMP(timezone=True),
+            nullable=True,
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("name", "tenant_id"),
+    )
+
+    # Add security level reference to spaces table
+    op.add_column(
+        "spaces",
+        sa.Column(
+            "security_level_id",
+            sa.UUID(),
+            sa.ForeignKey("security_levels.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+    # Add security level reference to completion model settings table
+    op.add_column(
+        "completion_model_settings",
+        sa.Column(
+            "security_level_id",
+            sa.UUID(),
+            sa.ForeignKey("security_levels.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+    # Add security level reference to embedding model settings table
+    op.add_column(
+        "embedding_model_settings",
+        sa.Column(
+            "security_level_id",
+            sa.UUID(),
+            sa.ForeignKey("security_levels.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    # Remove security level references
+    op.drop_column("embedding_model_settings", "security_level_id")
+    op.drop_column("completion_model_settings", "security_level_id")
+    op.drop_column("spaces", "security_level_id")
+
+    # Drop security levels table
+    op.drop_table("security_levels")

--- a/backend/src/intric/ai_models/completion_models/completion_model.py
+++ b/backend/src/intric/ai_models/completion_models/completion_model.py
@@ -7,7 +7,7 @@ from pydantic import BaseModel
 from intric.files.file_models import File
 from intric.logging.logging import LoggingDetails
 from intric.main.models import InDB, partial_model
-
+from intric.securitylevels.api.security_level_models import SecurityLevelPublic
 
 class CompletionModelFamily(str, Enum):
     OPEN_AI = "openai"
@@ -64,16 +64,19 @@ class CompletionModelUpdate(CompletionModelBase):
 class CompletionModelUpdateFlags(BaseModel):
     is_org_enabled: Optional[bool] = None
     is_org_default: Optional[bool] = None
+    security_level_id: Optional[UUID] = None
 
 
 class CompletionModel(CompletionModelBase, InDB):
     is_org_enabled: bool = False
     is_org_default: bool = False
+    security_level_id: Optional[UUID] = None
 
 
 class CompletionModelPublic(CompletionModel):
     can_access: bool = False
     is_locked: bool = True
+    security_level: Optional[SecurityLevelPublic] = None
 
 
 class CompletionModelResponse(BaseModel):

--- a/backend/src/intric/ai_models/embedding_models/embedding_model.py
+++ b/backend/src/intric/ai_models/embedding_models/embedding_model.py
@@ -10,6 +10,7 @@ from intric.ai_models.completion_models.completion_model import (
     Orgs,
 )
 from intric.main.models import InDB, partial_model
+from intric.securitylevels.api.security_level_models import SecurityLevelPublic
 
 
 class EmbeddingModelFamily(str, Enum):
@@ -43,11 +44,16 @@ class EmbeddingModelUpdate(EmbeddingModelBase):
 
 class EmbeddingModelUpdateFlags(BaseModel):
     is_org_enabled: Optional[bool] = False
+    security_level_id: Optional[UUID] = None
+
+
+class EmbeddingModelSecurityLevelUpdate(BaseModel):
+    security_level_id: UUID
 
 
 class EmbeddingModel(EmbeddingModelBase, InDB):
     is_org_enabled: bool = False
-
+    security_level_id: Optional[UUID] = None
 
 class EmbeddingModelPublicBase(EmbeddingModelBase, InDB):
     pass
@@ -56,6 +62,7 @@ class EmbeddingModelPublicBase(EmbeddingModelBase, InDB):
 class EmbeddingModelPublic(EmbeddingModel):
     can_access: bool = False
     is_locked: bool = True
+    security_level: Optional[SecurityLevelPublic] = None
 
 
 class EmbeddingModelSparse(EmbeddingModelBase, InDB):

--- a/backend/src/intric/completion_models/application/completion_model_crud_service.py
+++ b/backend/src/intric/completion_models/application/completion_model_crud_service.py
@@ -1,5 +1,5 @@
 from typing import TYPE_CHECKING, Optional
-
+from uuid import UUID
 from intric.completion_models.domain import ModelFamily
 from intric.main.config import SETTINGS
 from intric.main.exceptions import UnauthorizedException
@@ -10,14 +10,19 @@ if TYPE_CHECKING:
 
     from intric.completion_models.domain import CompletionModelRepository
     from intric.users.user import UserInDB
+    from intric.securitylevels.security_level_service import SecurityLevelService
 
 
 class CompletionModelCRUDService:
     def __init__(
-        self, user: "UserInDB", completion_model_repo: "CompletionModelRepository"
+        self,
+        user: "UserInDB",
+        completion_model_repo: "CompletionModelRepository",
+        security_level_service: "SecurityLevelService",
     ):
         self.completion_model_repo = completion_model_repo
         self.user = user
+        self.security_level_service = security_level_service
 
     async def get_completion_models(self):
         models = await self.completion_model_repo.all()
@@ -70,6 +75,7 @@ class CompletionModelCRUDService:
         model_id: "UUID",
         is_org_enabled: Optional[bool],
         is_org_default: Optional[bool],
+        security_level_id: Optional[UUID],
     ):
         completion_model = await self.completion_model_repo.one(model_id=model_id)
 
@@ -78,6 +84,8 @@ class CompletionModelCRUDService:
 
         if is_org_default is not None:
             completion_model.is_org_default = is_org_default
+
+        completion_model.security_level_id = security_level_id
 
         await self.completion_model_repo.update(completion_model)
 

--- a/backend/src/intric/completion_models/domain/completion_model.py
+++ b/backend/src/intric/completion_models/domain/completion_model.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
     from uuid import UUID
 
     from intric.users.user import UserInDB
+    from intric.securitylevels.api.security_level_models import SecurityLevelPublic
 
 
 class ModelFamily(str, Enum):
@@ -60,6 +61,7 @@ class CompletionModel:
         deployment_name: Optional[str],
         is_org_enabled: bool,
         is_org_default: bool,
+        security_level_id: Optional["UUID"] = None,
     ):
         self.user = user
         self.id = id
@@ -81,6 +83,7 @@ class CompletionModel:
         self.deployment_name = deployment_name
         self.is_org_enabled = is_org_enabled
         self.is_org_default = is_org_default
+        self.security_level_id = security_level_id
 
     @property
     def is_locked(self):

--- a/backend/src/intric/completion_models/domain/completion_model_factory.py
+++ b/backend/src/intric/completion_models/domain/completion_model_factory.py
@@ -28,10 +28,12 @@ class CompletionModelFactory:
             is_org_enabled = False
             is_org_default = False
             updated_at = completion_model.updated_at
+            security_level_id = None
         else:
             is_org_enabled = completion_model_settings.is_org_enabled
             is_org_default = completion_model_settings.is_org_default
             updated_at = completion_model_settings.updated_at
+            security_level_id = completion_model_settings.security_level_id
 
         org = None if completion_model.org is None else ModelOrg(completion_model.org)
 
@@ -56,4 +58,5 @@ class CompletionModelFactory:
             deployment_name=completion_model.deployment_name,
             is_org_enabled=is_org_enabled,
             is_org_default=is_org_default,
+            security_level_id=security_level_id,
         )

--- a/backend/src/intric/completion_models/domain/completion_model_repo.py
+++ b/backend/src/intric/completion_models/domain/completion_model_repo.py
@@ -101,6 +101,7 @@ class CompletionModelRepository:
                 tenant_id=self.user.tenant_id,
                 is_org_enabled=completion_model.is_org_enabled,
                 is_org_default=completion_model.is_org_default,
+                security_level_id=completion_model.security_level_id,
             )
             await self.session.execute(stmt)
 
@@ -110,6 +111,7 @@ class CompletionModelRepository:
                 .values(
                     is_org_enabled=completion_model.is_org_enabled,
                     is_org_default=completion_model.is_org_default,
+                    security_level_id=completion_model.security_level_id,
                 )
                 .where(
                     CompletionModelSettings.completion_model_id == completion_model.id,

--- a/backend/src/intric/completion_models/presentation/completion_model_assembler.py
+++ b/backend/src/intric/completion_models/presentation/completion_model_assembler.py
@@ -34,6 +34,7 @@ class CompletionModelAssembler:
             is_org_default=completion_model.is_org_default,
             can_access=completion_model.can_access,
             is_locked=completion_model.is_locked,
+            security_level_id=completion_model.security_level_id,
         )
 
     def from_completion_models_to_models(

--- a/backend/src/intric/completion_models/presentation/completion_models_router.py
+++ b/backend/src/intric/completion_models/presentation/completion_models_router.py
@@ -48,6 +48,7 @@ async def update_completion_model(
         model_id=id,
         is_org_enabled=update_flags.is_org_enabled,
         is_org_default=update_flags.is_org_default,
+        security_level_id=update_flags.security_level_id,
     )
 
     return assembler.from_completion_model_to_model(completion_model=completion_model)

--- a/backend/src/intric/database/tables/ai_models_table.py
+++ b/backend/src/intric/database/tables/ai_models_table.py
@@ -2,11 +2,11 @@ from typing import Optional
 from uuid import UUID
 
 from sqlalchemy import ForeignKey
-from sqlalchemy.orm import Mapped, mapped_column
+from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from intric.database.tables.base_class import BaseCrossReference, BasePublic
 from intric.database.tables.tenant_table import Tenants
-
+from intric.database.tables.security_levels_table import SecurityLevels
 
 class CompletionModels(BasePublic):
     name: Mapped[str] = mapped_column(unique=True)
@@ -36,6 +36,15 @@ class CompletionModelSettings(BaseCrossReference):
     is_org_enabled: Mapped[bool] = mapped_column(server_default="False")
     is_org_default: Mapped[bool] = mapped_column(server_default="False")
 
+    # Security level relationship
+    security_level_id: Mapped[Optional[UUID]] = mapped_column(
+        ForeignKey(SecurityLevels.id, ondelete="SET NULL"),
+        nullable=True
+    )
+    security_level: Mapped[Optional["SecurityLevels"]] = relationship(
+        back_populates="completion_model_settings"
+    )
+
 
 class EmbeddingModels(BasePublic):
     name: Mapped[str] = mapped_column(unique=True)
@@ -60,4 +69,12 @@ class EmbeddingModelSettings(BaseCrossReference):
         ForeignKey(EmbeddingModels.id, ondelete="CASCADE"), primary_key=True
     )
     is_org_enabled: Mapped[bool] = mapped_column(server_default="False")
-    is_org_default: Mapped[bool] = mapped_column(server_default="False")
+
+    # Security level relationship
+    security_level_id: Mapped[Optional[UUID]] = mapped_column(
+        ForeignKey(SecurityLevels.id, ondelete="SET NULL"),
+        nullable=True
+    )
+    security_level: Mapped[Optional["SecurityLevels"]] = relationship(
+        back_populates="embedding_model_settings"
+    )

--- a/backend/src/intric/database/tables/security_levels_table.py
+++ b/backend/src/intric/database/tables/security_levels_table.py
@@ -1,0 +1,46 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+from typing import TYPE_CHECKING, Optional
+from uuid import UUID
+
+from sqlalchemy import ForeignKey
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from intric.database.tables.base_class import BasePublic
+from intric.database.tables.tenant_table import Tenants
+
+if TYPE_CHECKING:
+    from intric.database.tables.ai_models_table import CompletionModelSettings, EmbeddingModelSettings
+    from intric.database.tables.spaces_table import Spaces
+
+
+class SecurityLevels(BasePublic):
+    """Table for storing security levels."""
+
+    # Core fields
+    name: Mapped[str] = mapped_column()
+    description: Mapped[Optional[str]] = mapped_column()
+    value: Mapped[int] = mapped_column()
+
+    # Tenant relationship
+    tenant_id: Mapped[UUID] = mapped_column(
+        ForeignKey(Tenants.id, ondelete="CASCADE"),
+        nullable=False,
+    )
+    tenant: Mapped["Tenants"] = relationship()
+
+    # Relationships
+    completion_model_settings: Mapped[list["CompletionModelSettings"]] = relationship(
+        back_populates="security_level",
+        order_by="CompletionModelSettings.created_at"
+    )
+    embedding_model_settings: Mapped[list["EmbeddingModelSettings"]] = relationship(
+        back_populates="security_level",
+        order_by="EmbeddingModelSettings.created_at"
+    )
+    spaces: Mapped[list["Spaces"]] = relationship(
+        back_populates="security_level",
+        order_by="Spaces.created_at"
+    )

--- a/backend/src/intric/database/tables/spaces_table.py
+++ b/backend/src/intric/database/tables/spaces_table.py
@@ -8,7 +8,7 @@ from intric.database.tables.ai_models_table import CompletionModels, EmbeddingMo
 from intric.database.tables.base_class import BaseCrossReference, BasePublic
 from intric.database.tables.tenant_table import Tenants
 from intric.database.tables.users_table import Users
-
+from intric.database.tables.security_levels_table import SecurityLevels
 if TYPE_CHECKING:
     from intric.database.tables.app_table import Apps
     from intric.database.tables.assistant_table import Assistants
@@ -26,8 +26,12 @@ class Spaces(BasePublic):
     user_id: Mapped[Optional[UUID]] = mapped_column(
         ForeignKey(Users.id, ondelete="CASCADE"), unique=True
     )
+    security_level_id: Mapped[Optional[UUID]] = mapped_column(
+        ForeignKey(SecurityLevels.id, ondelete="SET NULL")
+    )
 
     # Relationships
+    security_level: Mapped[Optional[SecurityLevels]] = relationship()
     embedding_models: Mapped[list[EmbeddingModels]] = relationship(
         secondary="spaces_embedding_models", order_by=EmbeddingModels.created_at
     )

--- a/backend/src/intric/main/container/container.py
+++ b/backend/src/intric/main/container/container.py
@@ -168,6 +168,9 @@ from intric.websites.website_repo import WebsiteRepository
 from intric.websites.website_service import WebsiteService
 from intric.worker.task_manager import TaskManager
 from intric.workflows.step_repo import StepRepository
+from intric.securitylevels.security_level_repo import SecurityLevelRepository
+from intric.securitylevels.security_level_service import SecurityLevelService
+from intric.securitylevels.api.security_level_assembler import SecurityLevelAssembler
 
 if SETTINGS.using_intric_proprietary:
     from intric_prop.apps.publish_app_service import PublishAppService
@@ -245,7 +248,7 @@ class Container(containers.DeclarativeContainer):
     integration_assembler = providers.Factory(IntegrationAssembler)
     tenant_integration_assembler = providers.Factory(TenantIntegrationAssembler)
     user_integration_assembler = providers.Factory(UserIntegrationAssembler)
-
+    security_level_assembler = providers.Factory(SecurityLevelAssembler)
     # Repositories
     user_repo = providers.Factory(UsersRepository, session=session)
     tenant_repo = providers.Factory(TenantRepository, session=session)
@@ -309,6 +312,10 @@ class Container(containers.DeclarativeContainer):
     storage_repo = providers.Factory(
         StorageInfoRepository, user=user, session=session, factory=storage_info_factory
     )
+    security_level_repo = providers.Factory(
+        SecurityLevelRepository,
+        session=session,
+    )
     space_repo = providers.Factory(
         SpaceRepository,
         user=user,
@@ -316,6 +323,7 @@ class Container(containers.DeclarativeContainer):
         session=session,
         assistant_repo=assistant_repo,
         app_repo=app_repo,
+        security_level_repo=security_level_repo,
     )
     app_template_repo = providers.Factory(
         AppTemplateRepository, factory=app_template_factory, session=session
@@ -325,6 +333,7 @@ class Container(containers.DeclarativeContainer):
     )
 
     module_repo = providers.Factory(ModuleRepository, session=session)
+
 
     # Completion model adapters
     openai_model_adapter = providers.Factory(OpenAIModelAdapter, model=completion_model)
@@ -370,17 +379,25 @@ class Container(containers.DeclarativeContainer):
     image_extractor = providers.Factory(ImageExtractor)
 
     # Services
+    security_level_service = providers.Factory(
+        SecurityLevelService,
+        user=user,
+        repo=security_level_repo,
+    )
+
     ai_models_service = providers.Factory(
         AIModelsService,
         user=user,
         embedding_model_repo=embedding_model_repo,
         completion_model_repo=completion_model_repo,
         tenant_repo=tenant_repo,
+        security_level_service=security_level_service,
     )
     completion_model_crud_service = providers.Factory(
         CompletionModelCRUDService,
         user=user,
         completion_model_repo=completion_model_repo2,
+        security_level_service=security_level_service
     )
     auth_service = providers.Factory(
         AuthService,
@@ -408,6 +425,7 @@ class Container(containers.DeclarativeContainer):
         ai_models_service=ai_models_service,
         completion_model_crud_service=completion_model_crud_service,
         actor_manager=actor_manager,
+        security_level_service=security_level_service,
     )
     storage_service = providers.Factory(StorageInfoService, repo=storage_repo)
     job_service = providers.Factory(

--- a/backend/src/intric/securitylevels/__init__.py
+++ b/backend/src/intric/securitylevels/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+"""Security Levels package."""

--- a/backend/src/intric/securitylevels/api/__init__.py
+++ b/backend/src/intric/securitylevels/api/__init__.py
@@ -1,0 +1,5 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+"""Security Levels API package."""

--- a/backend/src/intric/securitylevels/api/security_level_assembler.py
+++ b/backend/src/intric/securitylevels/api/security_level_assembler.py
@@ -1,0 +1,19 @@
+from intric.securitylevels.api.security_level_models import SecurityLevelPublic
+from intric.securitylevels.security_level import SecurityLevel
+from intric.users.user import UserInDB
+
+
+class SecurityLevelAssembler:
+    def __init__(self, user: UserInDB):
+        self.user = user
+
+    def from_security_level_to_model(self, security_level: SecurityLevel) -> SecurityLevelPublic:
+        return SecurityLevelPublic(
+            created_at=security_level.created_at,
+            updated_at=security_level.updated_at,
+            id=security_level.id,
+            name=security_level.name,
+            description=security_level.description,
+            value=security_level.value,
+            tenant_id=security_level.tenant_id,
+        )

--- a/backend/src/intric/securitylevels/api/security_level_models.py
+++ b/backend/src/intric/securitylevels/api/security_level_models.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel, Field
+
+from intric.main.models import InDB, partial_model
+
+
+class SecurityLevelBase(BaseModel):
+    """Base model for security level data."""
+
+    name: str = Field(..., description="Name of the security level")
+    description: Optional[str] = Field(
+        None, description="Description of the security level"
+    )
+    value: int = Field(
+        ..., description="Numeric value determining the security level hierarchy"
+    )
+
+
+class SecurityLevelCreatePublic(SecurityLevelBase):
+    """Request model for creating a new security level."""
+    pass
+
+
+@partial_model
+class SecurityLevelUpdatePublic(SecurityLevelCreatePublic):
+    """Request model for updating an existing security level."""
+
+
+class SecurityLevelSparse(InDB):
+    """Basic security level information."""
+    name: str
+    description: Optional[str]
+    value: int
+
+
+class SecurityLevelPublic(SecurityLevelSparse):
+    """Complete security level information including relationships."""
+    pass

--- a/backend/src/intric/securitylevels/api/security_level_router.py
+++ b/backend/src/intric/securitylevels/api/security_level_router.py
@@ -1,0 +1,149 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+from uuid import UUID
+
+from fastapi import APIRouter, Depends
+
+from intric.securitylevels.security_level_factory import get_security_level_service
+from intric.securitylevels.security_level_service import SecurityLevelService
+from intric.server.protocol import responses
+from intric.securitylevels.api.security_level_models import (
+    SecurityLevelCreatePublic,
+    SecurityLevelPublic,
+    SecurityLevelUpdatePublic,
+)
+
+router = APIRouter()
+
+
+@router.post(
+    "",
+    response_model=SecurityLevelPublic,
+    status_code=201,
+    responses=responses.get_responses([400, 409]),
+)
+async def create_security_level(
+    request: SecurityLevelCreatePublic,
+    service: SecurityLevelService = Depends(get_security_level_service),
+) -> SecurityLevelPublic:
+    """Create a new security level for the current tenant.
+
+    Args:
+        request: The security level creation request.
+
+    Returns:
+        The created security level.
+
+    Raises:
+        400: If the request is invalid.
+        409: If a security level with the same name already exists for this tenant.
+    """
+    security_level = await service.create_security_level(
+        name=request.name,
+        description=request.description,
+        value=request.value,
+    )
+    return SecurityLevelPublic.model_validate(security_level)
+
+
+@router.get(
+    "",
+    response_model=list[SecurityLevelPublic],
+    responses=responses.get_responses([403]),
+)
+async def list_security_levels(
+    service: SecurityLevelService = Depends(get_security_level_service),
+) -> list[SecurityLevelPublic]:
+    """List all security levels for the current tenant ordered by value.
+
+    Returns:
+        List of security levels ordered by value.
+
+    Raises:
+        403: If the user doesn't have permission to list security levels.
+    """
+    security_levels = await service.list_security_levels()
+    return [SecurityLevelPublic.model_validate(sl) for sl in security_levels]
+
+
+@router.get(
+    "/{id}",
+    response_model=SecurityLevelPublic,
+    responses=responses.get_responses([403, 404]),
+)
+async def get_security_level(
+    id: UUID,
+    service: SecurityLevelService = Depends(get_security_level_service),
+) -> SecurityLevelPublic:
+    """Get a security level by ID.
+
+    Args:
+        id: The ID of the security level.
+
+    Returns:
+        The security level.
+
+    Raises:
+        403: If the user doesn't have permission to view the security level.
+        404: If the security level doesn't exist or belongs to a different tenant.
+    """
+    security_level = await service.get_security_level(id)
+    return SecurityLevelPublic.model_validate(security_level)
+
+
+@router.patch(
+    "/{id}",
+    response_model=SecurityLevelPublic,
+    responses=responses.get_responses([400, 403, 404, 409]),
+)
+async def update_security_level(
+    id: UUID,
+    request: SecurityLevelUpdatePublic,
+    service: SecurityLevelService = Depends(get_security_level_service),
+) -> SecurityLevelPublic:
+    """Update a security level.
+
+    Args:
+        id: The ID of the security level to update.
+        request: The update request.
+
+    Returns:
+        The updated security level.
+
+    Raises:
+        400: If the request is invalid.
+        403: If the user doesn't have permission to update the security level.
+        404: If the security level doesn't exist or belongs to a different tenant.
+        409: If updating the name would create a duplicate within the tenant.
+    """
+    security_level = await service.update_security_level(
+        id=id,
+        name=request.name,
+        description=request.description,
+        value=request.value,
+    )
+    return SecurityLevelPublic.model_validate(security_level)
+
+
+@router.delete(
+    "/{id}",
+    status_code=204,
+    responses=responses.get_responses([403, 404, 409]),
+)
+async def delete_security_level(
+    id: UUID,
+    service: SecurityLevelService = Depends(get_security_level_service),
+) -> None:
+    """Delete a security level.
+
+    Args:
+        id: The ID of the security level to delete.
+
+    Raises:
+        403: If the user doesn't have permission to delete the security level.
+        404: If the security level doesn't exist or belongs to a different tenant.
+        409: If the security level is in use by any spaces or models.
+    """
+    await service.delete_security_level(id)

--- a/backend/src/intric/securitylevels/security_level.py
+++ b/backend/src/intric/securitylevels/security_level.py
@@ -1,0 +1,41 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SecurityLevelBase(BaseModel):
+    """Base model for security levels."""
+    name: str
+    description: str | None = None
+    value: int = 0
+
+
+class SecurityLevelCreate(SecurityLevelBase):
+    """Model for creating a security level."""
+    tenant_id: UUID
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SecurityLevelUpdate(SecurityLevelBase):
+    """Model for updating a security level."""
+    id: UUID
+    tenant_id: UUID
+    name: str | None = None
+    description: str | None = None
+    value: int | None = None
+    model_config = ConfigDict(from_attributes=True)
+
+
+class SecurityLevel(SecurityLevelBase):
+    """Domain model for security levels."""
+    id: UUID | None = None
+    tenant_id: UUID
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    deleted_at: datetime | None = None
+    model_config = ConfigDict(from_attributes=True)

--- a/backend/src/intric/securitylevels/security_level_factory.py
+++ b/backend/src/intric/securitylevels/security_level_factory.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+from fastapi import Depends
+
+from intric.main.container.container import Container
+from intric.server.dependencies.container import get_container
+
+
+def get_security_level_service(container: Container = Depends(get_container(with_user=True))):
+    return container.security_level_service()
+
+
+def get_security_level_service_from_assistant_api_key(
+    container: Container = Depends(
+        get_container(with_user_from_assistant_api_key=True)
+    ),
+):
+    return container.security_level_service()

--- a/backend/src/intric/securitylevels/security_level_repo.py
+++ b/backend/src/intric/securitylevels/security_level_repo.py
@@ -1,0 +1,78 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+from typing import Optional
+from uuid import UUID
+
+import sqlalchemy as sa
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from intric.database.repositories.base import BaseRepositoryDelegate
+from intric.database.tables.security_levels_table import SecurityLevels
+from intric.securitylevels.security_level import (
+    SecurityLevel,
+    SecurityLevelCreate,
+    SecurityLevelUpdate,
+)
+
+
+class SecurityLevelRepository:
+    """Repository for managing security levels."""
+
+    def __init__(self, session: AsyncSession):
+        self.delegate = BaseRepositoryDelegate(
+            session,
+            SecurityLevels,
+            SecurityLevel,
+        )
+        self.session = session
+
+    async def create(self, security_level: SecurityLevelCreate) -> SecurityLevel:
+        """Create a new security level."""
+        return await self.delegate.add(security_level)
+
+    async def get(self, id: UUID) -> Optional[SecurityLevel]:
+        """Get a security level by ID."""
+        return await self.delegate.get(id)
+
+    async def get_by_name_and_tenant(
+        self, name: str, tenant_id: UUID
+    ) -> Optional[SecurityLevel]:
+        """Get a security level by name and tenant."""
+        query = sa.select(SecurityLevels).where(
+            sa.and_(
+                SecurityLevels.name == name,
+                SecurityLevels.tenant_id == tenant_id
+            )
+        )
+        return await self.delegate.get_model_from_query(query)
+
+    async def list_by_tenant(self, tenant_id: UUID) -> list[SecurityLevel]:
+        """List all security levels for a tenant ordered by value."""
+        query = (
+            sa.select(SecurityLevels)
+            .where(SecurityLevels.tenant_id == tenant_id)
+            .order_by(SecurityLevels.value)
+        )
+        return await self.delegate.get_models_from_query(query)
+
+    async def update(self, security_level: SecurityLevelUpdate) -> SecurityLevel:
+        """Update an existing security level."""
+        return await self.delegate.update(security_level)
+
+    async def delete(self, id: UUID) -> bool:
+        """Delete a security level."""
+        await self.delegate.delete(id)
+        return True
+
+    async def get_highest_value_by_tenant(self, tenant_id: UUID) -> Optional[int]:
+        """Get the highest security level value for a tenant."""
+        stmt = (
+            sa.select(SecurityLevels.value)
+            .where(SecurityLevels.tenant_id == tenant_id)
+            .order_by(SecurityLevels.value.desc())
+        )
+        result = await self.session.execute(stmt)
+        value = result.scalar_one_or_none()
+        return value

--- a/backend/src/intric/securitylevels/security_level_service.py
+++ b/backend/src/intric/securitylevels/security_level_service.py
@@ -1,0 +1,111 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+from typing import Optional
+from uuid import UUID
+
+from intric.main.exceptions import BadRequestException, NotFoundException, UnauthorizedException
+from intric.roles.permissions import Permission, validate_permissions
+from intric.securitylevels.security_level import SecurityLevel, SecurityLevelCreate, SecurityLevelUpdate
+from intric.securitylevels.security_level_repo import SecurityLevelRepository
+from intric.users.user import UserInDB
+
+
+class SecurityLevelService:
+    """Service for managing security levels."""
+
+    def __init__(
+        self,
+        user: UserInDB,
+        repo: SecurityLevelRepository,
+    ):
+        self.user = user
+        self.repo = repo
+
+    def _validate(self, security_level: SecurityLevel, id: UUID):
+        """Validate security level exists and belongs to user's tenant."""
+        if security_level is None or security_level.tenant_id != self.user.tenant_id:
+            raise NotFoundException(f"Security level {id} not found")
+
+    @validate_permissions(Permission.ADMIN)
+    async def create_security_level(
+        self, name: str, description: Optional[str], value: int
+    ) -> SecurityLevel:
+        """Create a new security level."""
+        # Check if name already exists for this tenant
+        existing = await self.repo.get_by_name_and_tenant(name, self.user.tenant_id)
+        if existing:
+            raise BadRequestException(f"Security level with name '{name}' already exists")
+
+        security_level = SecurityLevelCreate(
+            name=name,
+            description=description,
+            value=value,
+            tenant_id=self.user.tenant_id,
+        )
+
+        return await self.repo.create(security_level)
+
+    async def get_security_level(self, id: UUID) -> SecurityLevel:
+        """Get a security level by ID."""
+        security_level = await self.repo.get(id)
+        self._validate(security_level, id)
+        return security_level
+
+    async def get_security_level_by_name(self, name: str) -> Optional[SecurityLevel]:
+        """Get a security level by name for the current tenant."""
+        return await self.repo.get_by_name_and_tenant(name, self.user.tenant_id)
+
+    async def list_security_levels(self) -> list[SecurityLevel]:
+        """List all security levels for the current tenant ordered by value."""
+        return await self.repo.list_by_tenant(self.user.tenant_id)
+
+    @validate_permissions(Permission.ADMIN)
+    async def update_security_level(
+        self,
+        id: UUID,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        value: Optional[int] = None,
+    ) -> SecurityLevel:
+        """Update a security level."""
+        security_level = await self.repo.get(id)
+        self._validate(security_level, id)
+
+        # Check if name already exists if updating name
+        if name:
+            existing = await self.repo.get_by_name_and_tenant(name, self.user.tenant_id)
+            if existing and existing.id != id:
+                raise BadRequestException(f"Security level with name '{name}' already exists")
+
+        # Create update model
+        update = SecurityLevelUpdate(
+            id=id,
+            tenant_id=self.user.tenant_id,
+            name=name if name is not None else security_level.name,
+            description=description if description is not None else security_level.description,
+            value=value if value is not None else security_level.value,
+        )
+
+        return await self.repo.update(update)
+
+    @validate_permissions(Permission.ADMIN)
+    async def delete_security_level(self, id: UUID) -> None:
+        """Delete a security level."""
+        security_level = await self.repo.get(id)
+        self._validate(security_level, id)
+        await self.repo.delete(security_level.id)
+
+    async def validate_security_level(
+        self, required_level: SecurityLevel, provided_level: SecurityLevel
+    ) -> bool:
+        """Validate if a provided security level meets the required level."""
+        # Ensure levels are from same tenant
+        if required_level.tenant_id != provided_level.tenant_id:
+            return False
+        return provided_level.value >= required_level.value
+
+    async def get_highest_security_level(self) -> Optional[int]:
+        """Get the highest security level value for the current tenant."""
+        return await self.repo.get_highest_value_by_tenant(self.user.tenant_id)

--- a/backend/src/intric/server/routers.py
+++ b/backend/src/intric/server/routers.py
@@ -40,6 +40,7 @@ from intric.user_groups.user_groups_router import router as user_groups_router
 from intric.users.user_router import router as users_router
 from intric.websites.website_router import router as website_router
 from intric.integration.presentation.integration_router import router as integration_router
+from intric.securitylevels.api.security_level_router import router as security_level_router
 
 router = APIRouter()
 
@@ -55,6 +56,7 @@ router.include_router(services_router, prefix="/services", tags=["services"])
 router.include_router(logging_router, prefix="/logging", tags=["logging"])
 router.include_router(analysis_router, prefix="/analysis", tags=["analysis"])
 router.include_router(admin_router, prefix="/admin", tags=["admin"])
+router.include_router(security_level_router, prefix="/security-levels", tags=["security-levels"])
 router.include_router(jobs_router, prefix="/jobs", tags=["jobs"])
 router.include_router(user_groups_router, prefix="/user-groups", tags=["user-groups"])
 router.include_router(

--- a/backend/src/intric/spaces/api/space_assembler.py
+++ b/backend/src/intric/spaces/api/space_assembler.py
@@ -17,10 +17,12 @@ from intric.spaces.api.space_models import (
     SpacePublic,
     SpaceRole,
     SpaceSparse,
+    SpaceUpdateDryRunResponse,
 )
 from intric.spaces.space import Space
 from intric.users.user import UserInDB
 from intric.websites.website_models import WebsiteSparse
+from intric.spaces.space_service import SpaceUpdateAnalysis
 
 if TYPE_CHECKING:
     from intric.actors import ActorManager
@@ -276,6 +278,7 @@ class SpaceAssembler:
             personal=space.is_personal(),
             permissions=self._get_space_permissions(space),
             available_roles=available_roles,
+            security_level=space.security_level,
         )
 
     def from_space_to_sparse_model(self, space: Space) -> SpaceSparse:
@@ -287,6 +290,7 @@ class SpaceAssembler:
             description=space.description,
             personal=space.is_personal(),
             permissions=self._get_space_permissions(space),
+            security_level=space.security_level,
         )
 
     def from_space_to_dashboard_model(self, space: Space) -> SpaceDashboard:
@@ -320,4 +324,13 @@ class SpaceAssembler:
         return CreateSpaceGroupsResponse(
             **group.model_dump(),
             metadata=GroupMetadata(num_info_blobs=count, size=group.size),
+        )
+
+    @staticmethod
+    def from_space_analyze_update_to_response(analysis: SpaceUpdateAnalysis) -> SpaceUpdateDryRunResponse:
+        return SpaceUpdateDryRunResponse(
+            unavailable_completion_models=analysis.unavailable_completion_models,
+            unavailable_embedding_models=analysis.unavailable_embedding_models,
+            current_security_level=analysis.current_security_level,
+            new_security_level=analysis.new_security_level,
         )

--- a/backend/src/intric/spaces/space.py
+++ b/backend/src/intric/spaces/space.py
@@ -10,6 +10,7 @@ from intric.ai_models.embedding_models.embedding_model import (
 from intric.main.exceptions import BadRequestException, UnauthorizedException
 from intric.spaces.api.space_models import SpaceMember, SpaceRoleValue
 from intric.websites.website_models import WebsiteSparse
+from intric.securitylevels.security_level import SecurityLevel
 
 if TYPE_CHECKING:
     from intric.apps import App
@@ -46,6 +47,7 @@ class Space:
         members: dict[UUID, SpaceMember],
         created_at: datetime = None,
         updated_at: datetime = None,
+        security_level: Optional[SecurityLevel] = None,
     ):
         self.id = id
         self.tenant_id = tenant_id
@@ -63,6 +65,7 @@ class Space:
         self.members = members
         self.created_at = created_at
         self.updated_at = updated_at
+        self.security_level = security_level
 
     def _get_member_ids(self):
         return self.members.keys()
@@ -158,6 +161,7 @@ class Space:
         description: str = None,
         embedding_models: list[EmbeddingModelPublic] = None,
         completion_models: list["CompletionModel"] = None,
+        security_level: SecurityLevel = None,
     ):
         if name is not None:
             if self.is_personal():
@@ -188,6 +192,8 @@ class Space:
                 )
 
             self.embedding_models = embedding_models
+
+        self.security_level = security_level
 
     def add_member(self, user: SpaceMember):
         if self.is_personal():

--- a/backend/src/intric/spaces/space_factory.py
+++ b/backend/src/intric/spaces/space_factory.py
@@ -1,5 +1,6 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
+from intric.securitylevels.security_level import SecurityLevel
 from intric.ai_models.embedding_models.embedding_model import EmbeddingModel
 from intric.completion_models.domain import CompletionModelFactory
 from intric.database.tables.ai_models_table import (
@@ -59,6 +60,7 @@ class SpaceFactory:
         default_assistant: "Assistant" = None,
         assistants: list["Assistant"] = [],
         apps: list["App"] = [],
+        security_level: Optional[SecurityLevel] = None,
     ) -> Space:
         completion_models = [
             CompletionModelFactory.create_from_db(
@@ -120,4 +122,5 @@ class SpaceFactory:
             websites=websites,
             completion_models=completion_models,
             members=members,
+            security_level=security_level,
         )

--- a/backend/src/intric/spaces/space_repo.py
+++ b/backend/src/intric/spaces/space_repo.py
@@ -347,6 +347,7 @@ class SpaceRepository:
             completion_models_in_db=completion_models,
             embedding_models_in_db=embedding_models,
             default_assistant=space.default_assistant,
+            security_level=space.security_level,
         )
 
     async def delete(self, id: UUID):

--- a/backend/src/intric/spaces/space_repo.py
+++ b/backend/src/intric/spaces/space_repo.py
@@ -30,11 +30,12 @@ from intric.main.exceptions import NotFoundException, UniqueException
 from intric.spaces.api.space_models import SpaceMember
 from intric.spaces.space import Space
 from intric.spaces.space_factory import SpaceFactory
-
+from intric.securitylevels.security_level import SecurityLevel
 if TYPE_CHECKING:
     from intric.apps import AppRepository
     from intric.assistants.assistant import Assistant
     from intric.assistants.assistant_repo import AssistantRepository
+    from intric.securitylevels.security_level_repo import SecurityLevelRepository
     from intric.users.user import UserInDB
 
 
@@ -46,12 +47,14 @@ class SpaceRepository:
         factory: SpaceFactory,
         assistant_repo: "AssistantRepository",
         app_repo: Optional["AppRepository"],
+        security_level_repo: "SecurityLevelRepository",
     ):
         self.session = session
         self.user = user
         self.factory = factory
         self.assistant_repo = assistant_repo
         self.app_repo = app_repo
+        self.security_level_repo = security_level_repo
 
     def _options(self):
         return [
@@ -190,6 +193,12 @@ class SpaceRepository:
         # This allows the newly added members to be reflected in the space
         await self.session.refresh(space_in_db)
 
+    async def _set_security_level(
+        self, space_in_db: Spaces, security_level: SecurityLevel
+    ):
+        stmt = sa.update(Spaces).values(security_level_id=security_level.id if security_level else None).where(Spaces.id == space_in_db.id)
+        await self.session.execute(stmt)
+
     async def _set_default_assistant(
         self, space_in_db: Spaces, assistant: Optional["Assistant"]
     ):
@@ -242,7 +251,7 @@ class SpaceRepository:
         assistants = await self.assistant_repo.get_by_space(entry_in_db.id)
 
         apps = await self._get_apps(entry_in_db.id)
-
+        security_level = await self.security_level_repo.get(entry_in_db.security_level_id)
         return self.factory.create_space_from_db(
             entry_in_db,
             user=self.user,
@@ -252,6 +261,7 @@ class SpaceRepository:
             default_assistant=default_assistant,
             assistants=assistants,
             apps=apps,
+            security_level=security_level,
         )
 
     async def _get_record_with_options(self, query):
@@ -325,6 +335,7 @@ class SpaceRepository:
         await self._set_embedding_models(entry_in_db, space.embedding_models)
         await self._set_members(entry_in_db, space.members)
         await self._set_default_assistant(entry_in_db, space.default_assistant)
+        await self._set_security_level(entry_in_db, space.security_level)
 
         completion_models = await self._get_completion_models(entry_in_db)
         embedding_models = await self._get_embedding_models(entry_in_db)

--- a/backend/src/intric/spaces/space_service.py
+++ b/backend/src/intric/spaces/space_service.py
@@ -1,24 +1,45 @@
-from typing import TYPE_CHECKING
+# Copyright (c) 2024 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+from dataclasses import dataclass
+from typing import Optional
 from uuid import UUID
 
 from intric.ai_models.ai_models_service import AIModelsService
-from intric.ai_models.completion_models.completion_model import CompletionModelPublic
-from intric.ai_models.embedding_models.embedding_model import EmbeddingModelPublic
+from intric.ai_models.completion_models.completion_model import CompletionModelPublic, CompletionModelSparse
+from intric.ai_models.embedding_models.embedding_model import EmbeddingModelPublic, EmbeddingModelSparse
 from intric.main.exceptions import (
     BadRequestException,
     NotFoundException,
     UnauthorizedException,
 )
+from intric.securitylevels.security_level import SecurityLevel
+from intric.securitylevels.security_level_service import SecurityLevelService
 from intric.spaces.api.space_models import SpaceMember, SpaceRoleValue
 from intric.spaces.space import Space
 from intric.spaces.space_factory import SpaceFactory
 from intric.spaces.space_repo import SpaceRepository
 from intric.users.user import UserInDB
 from intric.users.user_repo import UsersRepository
+from intric.completion_models.domain.completion_model import CompletionModel
 
-if TYPE_CHECKING:
-    from intric.actors import ActorManager
-    from intric.completion_models.application import CompletionModelCRUDService
+
+@dataclass
+class SpaceUpdateAnalysis:
+    """Analysis of the impact of updating a space's properties."""
+
+    def __init__(
+        self,
+        current_security_level: Optional[SecurityLevel],
+        new_security_level: Optional[SecurityLevel],
+        unavailable_completion_models: list[CompletionModelPublic],
+        unavailable_embedding_models: list[EmbeddingModelPublic],
+    ):
+        self.current_security_level = current_security_level
+        self.new_security_level = new_security_level
+        self.unavailable_completion_models = unavailable_completion_models
+        self.unavailable_embedding_models = unavailable_embedding_models
 
 
 class SpaceService:
@@ -31,6 +52,7 @@ class SpaceService:
         ai_models_service: AIModelsService,
         completion_model_crud_service: "CompletionModelCRUDService",
         actor_manager: "ActorManager",
+        security_level_service: SecurityLevelService,
     ):
         self.user = user
         self.factory = factory
@@ -39,6 +61,7 @@ class SpaceService:
         self.ai_models_service = ai_models_service
         self.completion_model_crud_service = completion_model_crud_service
         self.actor_manager = actor_manager
+        self.security_level_service = security_level_service
 
     def _get_actor(self, space: Space):
         return self.actor_manager.get_space_actor_from_space(space)
@@ -108,42 +131,66 @@ class SpaceService:
 
         return space
 
+    async def _get_filtered_model_ids(
+        self,
+        current_models: list[CompletionModelSparse | EmbeddingModelSparse],
+        unavailable_models: list[CompletionModelSparse | EmbeddingModelSparse]
+    ) -> list[UUID]:
+        """Helper to get IDs of models that will remain available."""
+        unavailable_ids = {model.id for model in unavailable_models}
+        return [model.id for model in current_models if model.id not in unavailable_ids]
+
     async def update_space(
         self,
         id: UUID,
-        name: str = None,
-        description: str = None,
-        embedding_model_ids: list[UUID] = None,
-        completion_model_ids: list[UUID] = None,
+        name: Optional[str] = None,
+        description: Optional[str] = None,
+        embedding_model_ids: Optional[list[UUID]] = None,
+        completion_model_ids: Optional[list[UUID]] = None,
+        security_level_id: Optional[UUID] = None,
     ) -> Space:
+        """Update a space."""
         space = await self.get_space(id)
         actor = self._get_actor(space)
 
         if not actor.can_edit_space():
             raise UnauthorizedException("User does not have permission to edit space")
 
-        completion_models = None
-        if completion_model_ids is not None:
-            completion_models = [
-                await self.completion_model_crud_service.get_completion_model(
-                    model_id=model_id
-                )
-                for model_id in completion_model_ids
-            ]
+        update_kwargs = {
+            "name": name,
+            "description": description,
+            "security_level": None if security_level_id is None else await self.security_level_service.get_security_level(security_level_id)
+        }
 
-        embedding_models = None
+        # If security level is changing, analyze impact on models
+        if security_level_id is not None and (space.security_level is None or security_level_id != space.security_level.id):
+            analysis = await self.analyze_update(id, security_level_id)
+
+            # If no explicit model IDs provided, filter out incompatible models
+            if completion_model_ids is None:
+                completion_model_ids = await self._get_filtered_model_ids(
+                    space.completion_models,
+                    analysis.unavailable_completion_models
+                )
+            if embedding_model_ids is None:
+                embedding_model_ids = await self._get_filtered_model_ids(
+                    space.embedding_models,
+                    analysis.unavailable_embedding_models
+                )
+
+        # Fetch and set models if IDs are provided (either explicitly or from filtering)
+        if completion_model_ids is not None:
+            # Get full Public models
+            update_kwargs["completion_models"] = await self.ai_models_service.get_completion_models(
+                id_list=completion_model_ids,
+            )
         if embedding_model_ids is not None:
-            embedding_models = await self.ai_models_service.get_embedding_models(
-                id_list=embedding_model_ids
+            # Get full Public models
+            update_kwargs["embedding_models"] = await self.ai_models_service.get_embedding_models(
+                id_list=embedding_model_ids,
             )
 
-        space.update(
-            name=name,
-            description=description,
-            completion_models=completion_models,
-            embedding_models=embedding_models,
-        )
-
+        space.update(**update_kwargs)
         return await self.repo.update(space)
 
     async def delete_personal_space(self, user: UserInDB):
@@ -247,3 +294,62 @@ class SpaceService:
             return
 
         return await self._add_models_to_personal_space(personal_space)
+
+    async def _get_unavailable_models_for_security_level(
+        self,
+        models: list[CompletionModelSparse | EmbeddingModelSparse],
+        new_security_level: Optional[SecurityLevel],
+        get_full_model_fn
+    ) -> list[CompletionModelSparse | EmbeddingModelSparse]:
+        """Helper to find models that will become unavailable with new security level."""
+        unavailable = []
+        for model in models:
+            full_model = await get_full_model_fn(model.id, include_non_accessible=True)
+            if not full_model.security_level or (
+                new_security_level
+                and full_model.security_level.value < new_security_level.value
+            ):
+                unavailable.append(model)
+        return unavailable
+
+    async def analyze_update(
+        self,
+        id: UUID,
+        security_level_id: Optional[UUID] = None,
+    ) -> SpaceUpdateAnalysis:
+        """
+        Analyze the impact of updating a space's properties without actually applying the changes.
+        Currently supports:
+        - Security level changes: Shows which models would be affected
+        """
+        space = await self.get_space(id)
+        new_security_level = None
+        if security_level_id is not None:
+            new_security_level = await self.security_level_service.get_security_level(security_level_id)
+
+        # Check which models will be affected
+        unavailable_completion_models = []
+        for model in space.completion_models:
+            # Get the full model from the list of all models
+            all_models = await self.ai_models_service.get_completion_models(id_list=[model.id])
+            if not all_models:
+                continue
+            full_model = all_models[0]
+            if not full_model.security_level or (
+                new_security_level
+                and full_model.security_level.value < new_security_level.value
+            ):
+                unavailable_completion_models.append(full_model)
+
+        unavailable_embedding_models = await self._get_unavailable_models_for_security_level(
+            space.embedding_models,
+            new_security_level,
+            self.ai_models_service.get_embedding_model
+        )
+
+        return SpaceUpdateAnalysis(
+            current_security_level=space.security_level,
+            new_security_level=new_security_level,
+            unavailable_completion_models=unavailable_completion_models,
+            unavailable_embedding_models=unavailable_embedding_models,
+        )

--- a/backend/src/intric/spaces/space_service.py
+++ b/backend/src/intric/spaces/space_service.py
@@ -22,8 +22,6 @@ from intric.spaces.space_factory import SpaceFactory
 from intric.spaces.space_repo import SpaceRepository
 from intric.users.user import UserInDB
 from intric.users.user_repo import UsersRepository
-from intric.completion_models.domain.completion_model import CompletionModel
-
 
 @dataclass
 class SpaceUpdateAnalysis:

--- a/backend/tests/unittests/ai_models/test_ai_models_service.py
+++ b/backend/tests/unittests/ai_models/test_ai_models_service.py
@@ -71,6 +71,7 @@ def service_with_mocks():
         embedding_model_repo=AsyncMock(),
         completion_model_repo=AsyncMock(),
         tenant_repo=AsyncMock(),
+        security_level_service=AsyncMock(),
     )
 
 

--- a/backend/tests/unittests/securitylevels/test_security_level_service.py
+++ b/backend/tests/unittests/securitylevels/test_security_level_service.py
@@ -1,0 +1,354 @@
+# Copyright (c) 2025 Sundsvalls Kommun
+#
+# Licensed under the MIT License.
+
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from intric.main.exceptions import BadRequestException, NotFoundException, UnauthorizedException
+from intric.roles.permissions import Permission
+from intric.securitylevels.security_level import SecurityLevel
+from intric.securitylevels.security_level_service import SecurityLevelService
+from tests.fixtures import TEST_UUID, TEST_TENANT
+
+TEST_NAME = "test_security_level"
+TEST_DESCRIPTION = "A test security level"
+TEST_VALUE = 100
+
+
+@pytest.fixture
+def service():
+    repo = AsyncMock()
+    # Default to no existing security level with any name
+    repo.get_by_name_and_tenant.return_value = None
+
+    user = MagicMock()
+    user.permissions = []  # Default to no permissions
+    user.tenant_id = TEST_TENANT.id
+
+    return SecurityLevelService(
+        repo=repo,
+        user=user,
+    )
+
+
+@pytest.fixture
+def security_level():
+    return SecurityLevel(
+        id=TEST_UUID,
+        name=TEST_NAME,
+        description=TEST_DESCRIPTION,
+        value=TEST_VALUE,
+        tenant_id=TEST_TENANT.id,
+        created_at=None,
+        updated_at=None,
+    )
+
+
+async def test_create_security_level(service, security_level):
+    """Test creating a security level."""
+    # Setup
+    service.user.permissions = [Permission.ADMIN]
+    service.repo.create.return_value = security_level
+
+    # Execute
+    result = await service.create_security_level(
+        name=TEST_NAME,
+        description=TEST_DESCRIPTION,
+        value=TEST_VALUE,
+    )
+
+    # Assert
+    assert result == security_level
+    service.repo.create.assert_called_once()
+
+
+async def test_create_security_level_no_permission(service):
+    """Test creating a security level without admin permission."""
+    # Setup - no permissions by default
+
+    # Execute & Assert
+    with pytest.raises(UnauthorizedException):
+        await service.create_security_level(
+            name=TEST_NAME,
+            description=TEST_DESCRIPTION,
+            value=TEST_VALUE,
+        )
+
+    service.repo.create.assert_not_called()
+
+
+async def test_create_security_level_duplicate_name(service, security_level):
+    """Test creating a security level with duplicate name."""
+    # Setup
+    service.user.permissions = [Permission.ADMIN]
+    service.repo.get_by_name_and_tenant.return_value = security_level
+
+    # Execute & Assert
+    with pytest.raises(BadRequestException):
+        await service.create_security_level(
+            name=TEST_NAME,
+            description=TEST_DESCRIPTION,
+            value=TEST_VALUE,
+        )
+
+    service.repo.create.assert_not_called()
+
+
+async def test_get_security_level(service, security_level):
+    """Test getting a security level."""
+    # Setup
+    service.repo.get.return_value = security_level
+
+    # Execute
+    result = await service.get_security_level(TEST_UUID)
+
+    # Assert
+    assert result == security_level
+    service.repo.get.assert_called_once_with(TEST_UUID)
+
+
+async def test_get_security_level_not_found(service):
+    """Test getting a non-existent security level."""
+    # Setup
+    service.repo.get.return_value = None
+
+    # Execute & Assert
+    with pytest.raises(NotFoundException):
+        await service.get_security_level(TEST_UUID)
+
+
+async def test_get_security_level_wrong_tenant(service, security_level):
+    """Test getting a security level from wrong tenant."""
+    # Setup
+    wrong_tenant_level = SecurityLevel(
+        id=TEST_UUID,
+        name=TEST_NAME,
+        description=TEST_DESCRIPTION,
+        value=TEST_VALUE,
+        tenant_id=uuid4(),  # Different tenant
+        created_at=None,
+        updated_at=None,
+    )
+    service.repo.get.return_value = wrong_tenant_level
+
+    # Execute & Assert
+    with pytest.raises(NotFoundException):
+        await service.get_security_level(TEST_UUID)
+
+
+async def test_list_security_levels(service, security_level):
+    """Test listing security levels."""
+    # Setup
+    service.repo.list_by_tenant.return_value = [security_level]
+
+    # Execute
+    result = await service.list_security_levels()
+
+    # Assert
+    assert result == [security_level]
+    service.repo.list_by_tenant.assert_called_once_with(TEST_TENANT.id)
+
+
+async def test_update_security_level(service, security_level):
+    """Test updating a security level."""
+    # Setup
+    service.user.permissions = [Permission.ADMIN]
+    service.repo.get.return_value = security_level
+    service.repo.update.return_value = security_level
+
+    # Execute
+    result = await service.update_security_level(
+        id=TEST_UUID,
+        name="updated_name",
+        description="updated_description",
+        value=200,
+    )
+
+    # Assert
+    assert result == security_level
+    service.repo.update.assert_called_once()
+
+
+async def test_update_security_level_not_found(service):
+    """Test updating a non-existent security level."""
+    # Setup
+    service.user.permissions = [Permission.ADMIN]
+    service.repo.get.return_value = None
+
+    # Execute & Assert
+    with pytest.raises(NotFoundException):
+        await service.update_security_level(
+            id=TEST_UUID,
+            name="updated_name",
+        )
+
+    service.repo.update.assert_not_called()
+
+
+async def test_update_security_level_wrong_tenant(service, security_level):
+    """Test updating a security level from wrong tenant."""
+    # Setup
+    service.user.permissions = [Permission.ADMIN]
+    wrong_tenant_level = SecurityLevel(
+        id=TEST_UUID,
+        name=TEST_NAME,
+        description=TEST_DESCRIPTION,
+        value=TEST_VALUE,
+        tenant_id=uuid4(),  # Different tenant
+        created_at=None,
+        updated_at=None,
+    )
+    service.repo.get.return_value = wrong_tenant_level
+
+    # Execute & Assert
+    with pytest.raises(NotFoundException):
+        await service.update_security_level(
+            id=TEST_UUID,
+            name="updated_name",
+        )
+
+    service.repo.update.assert_not_called()
+
+
+async def test_update_security_level_no_permission(service, security_level):
+    """Test updating a security level without admin permission."""
+    # Setup
+    service.repo.get.return_value = security_level
+    # No permissions by default
+
+    # Execute & Assert
+    with pytest.raises(UnauthorizedException):
+        await service.update_security_level(
+            id=TEST_UUID,
+            name="updated_name",
+        )
+
+    service.repo.update.assert_not_called()
+
+
+async def test_update_security_level_duplicate_name(service, security_level):
+    """Test updating a security level with duplicate name."""
+    # Setup
+    service.user.permissions = [Permission.ADMIN]
+    service.repo.get.return_value = security_level
+    service.repo.get_by_name_and_tenant.return_value = SecurityLevel(
+        id=uuid4(),
+        name="existing_name",
+        value=0,
+        tenant_id=TEST_TENANT.id,
+    )
+
+    # Execute & Assert
+    with pytest.raises(BadRequestException):
+        await service.update_security_level(
+            id=TEST_UUID,
+            name="existing_name",
+        )
+
+    service.repo.update.assert_not_called()
+
+
+async def test_delete_security_level(service, security_level):
+    """Test deleting a security level."""
+    # Setup
+    service.user.permissions = [Permission.ADMIN]
+    service.repo.get.return_value = security_level
+
+    # Execute
+    await service.delete_security_level(TEST_UUID)
+
+    # Assert
+    service.repo.delete.assert_called_once_with(TEST_UUID)
+
+
+async def test_delete_security_level_not_found(service):
+    """Test deleting a non-existent security level."""
+    # Setup
+    service.user.permissions = [Permission.ADMIN]
+    service.repo.get.return_value = None
+
+    # Execute & Assert
+    with pytest.raises(NotFoundException):
+        await service.delete_security_level(TEST_UUID)
+
+    service.repo.delete.assert_not_called()
+
+
+async def test_delete_security_level_wrong_tenant(service, security_level):
+    """Test deleting a security level from wrong tenant."""
+    # Setup
+    service.user.permissions = [Permission.ADMIN]
+    wrong_tenant_level = SecurityLevel(
+        id=TEST_UUID,
+        name=TEST_NAME,
+        description=TEST_DESCRIPTION,
+        value=TEST_VALUE,
+        tenant_id=uuid4(),  # Different tenant
+        created_at=None,
+        updated_at=None,
+    )
+    service.repo.get.return_value = wrong_tenant_level
+
+    # Execute & Assert
+    with pytest.raises(NotFoundException):
+        await service.delete_security_level(TEST_UUID)
+
+    service.repo.delete.assert_not_called()
+
+
+async def test_delete_security_level_no_permission(service, security_level):
+    """Test deleting a security level without admin permission."""
+    # Setup
+    service.repo.get.return_value = security_level
+    # No permissions by default
+
+    # Execute & Assert
+    with pytest.raises(UnauthorizedException):
+        await service.delete_security_level(TEST_UUID)
+
+    service.repo.delete.assert_not_called()
+
+
+async def test_validate_security_level(service, security_level):
+    """Test validating security levels."""
+    # Setup
+    required = SecurityLevel(
+        id=uuid4(),
+        name="required",
+        value=100,
+        tenant_id=TEST_TENANT.id,
+    )
+    provided = SecurityLevel(
+        id=uuid4(),
+        name="provided",
+        value=200,
+        tenant_id=TEST_TENANT.id,
+    )
+
+    # Execute & Assert
+    assert await service.validate_security_level(required, provided) is True
+
+    # Test with lower value
+    provided.value = 50
+    assert await service.validate_security_level(required, provided) is False
+
+    # Test with different tenant
+    provided.value = 200
+    provided.tenant_id = uuid4()
+    assert await service.validate_security_level(required, provided) is False
+
+
+async def test_get_highest_security_level(service):
+    """Test getting the highest security level value."""
+    # Setup
+    service.repo.get_highest_value_by_tenant.return_value = TEST_VALUE
+
+    # Execute
+    result = await service.get_highest_security_level()
+
+    # Assert
+    assert result == TEST_VALUE
+    service.repo.get_highest_value_by_tenant.assert_called_once_with(TEST_TENANT.id)

--- a/backend/tests/unittests/spaces/api/test_space_assembler.py
+++ b/backend/tests/unittests/spaces/api/test_space_assembler.py
@@ -60,6 +60,7 @@ def space():
         user_id=None,
         tenant_id=TEST_UUID,
         description=None,
+        security_level=None,
         embedding_models=[],
         completion_models=[],
         assistants=[],

--- a/backend/tests/unittests/spaces/test_space.py
+++ b/backend/tests/unittests/spaces/test_space.py
@@ -1,11 +1,32 @@
 from datetime import datetime
 from unittest.mock import MagicMock
 from uuid import uuid4
+from functools import wraps
 
 import pytest
 
+from intric.main.config import SETTINGS
 from intric.main.exceptions import BadRequestException, UnauthorizedException
+from intric.modules.module import Modules
+from intric.roles.permissions import Permission
 from intric.spaces.space import UNAUTHORIZED_EXCEPTION_MESSAGE, Space, SpaceRoleValue
+
+
+def only_intric_proprietary(func):
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        if not SETTINGS.using_intric_proprietary:
+            pytest.skip("Test skipped when not using intric proprietary")
+        return func(*args, **kwargs)
+
+    return wrapper
+
+
+@pytest.fixture(autouse=True)
+def restore_intric_proprietary_setting():
+    original_value = SETTINGS.using_intric_proprietary
+    yield
+    SETTINGS.using_intric_proprietary = original_value
 
 
 @pytest.fixture

--- a/backend/tests/unittests/spaces/test_space_service.py
+++ b/backend/tests/unittests/spaces/test_space_service.py
@@ -7,7 +7,9 @@ import pytest
 from intric.main.exceptions import BadRequestException, UnauthorizedException
 from intric.spaces.api.space_models import SpaceRoleValue
 from intric.spaces.space_service import SpaceService
-from tests.fixtures import TEST_USER
+from tests.fixtures import TEST_USER, TEST_UUID, TEST_TENANT
+from intric.securitylevels.security_level import SecurityLevel
+from intric.spaces.space import Space
 
 
 @pytest.fixture
@@ -26,6 +28,7 @@ def service(actor: MagicMock):
         factory=MagicMock(),
         user_repo=AsyncMock(),
         ai_models_service=AsyncMock(),
+        security_level_service=AsyncMock(),
         user=TEST_USER,
         actor_manager=actor_manager,
     )
@@ -159,3 +162,94 @@ async def test_get_spaces_and_personal_space_returns_personal_space_first(
     spaces = await service.get_spaces(include_personal=True)
 
     assert spaces == [personal_space] + other_spaces
+
+
+@pytest.fixture
+def security_level():
+    return SecurityLevel(
+        id=TEST_UUID,
+        tenant_id=TEST_TENANT.id,
+        name="test_level",
+        description="Test security level",
+        value=100,
+        created_at="2024-01-01T00:00:00",
+        updated_at="2024-01-01T00:00:00",
+    )
+
+
+@pytest.fixture
+def higher_security_level():
+    return SecurityLevel(
+        id=uuid4(),
+        tenant_id=TEST_TENANT.id,
+        name="high_level",
+        description="High security level",
+        value=200,
+        created_at="2024-01-01T00:00:00",
+        updated_at="2024-01-01T00:00:00",
+    )
+
+
+async def test_update_space_security_level(
+    service: SpaceService, security_level: SecurityLevel
+):
+    """Test updating a space's security level."""
+    space = MagicMock()
+    space.can_edit.return_value = True
+
+    service.get_space = AsyncMock(return_value=space)
+    service.security_level_service.get_security_level = AsyncMock(return_value=security_level)
+    service.ai_models_service.get_completion_models = AsyncMock(return_value=[])
+    service.ai_models_service.get_embedding_models = AsyncMock(return_value=[])
+
+    await service.update_space(
+        id=TEST_UUID,
+        security_level_id=security_level.id,
+    )
+
+    # Check that update was called with the security level
+    space.update.assert_called_once_with(
+        name=None,
+        description=None,
+        completion_models=[],
+        embedding_models=[],
+        security_level=security_level,
+    )
+
+async def test_update_space_with_inaccessible_models_raises_unauthorized(service: SpaceService):
+    """
+    Test that validates that the behavior of updating a space with inaccessible models raises UnauthorizedException.
+    TODO: Verify that this is not a bug. When a model is deactivated on the organization and still activated on a space, the space can not toggle any of the other models.
+    """
+    # Create a real Space instance
+    space = Space(
+        id=TEST_UUID,
+        tenant_id=TEST_UUID,
+        user_id=None,
+        name="Test Space",
+        description=None,
+        embedding_models=[],
+        completion_models=[],
+        assistants=[],
+        services=[],
+        websites=[],
+        groups=[],
+        members={TEST_USER.id: MagicMock(role=SpaceRoleValue.ADMIN)},
+        default_assistant=None,
+        apps=[],
+    )
+
+    # Create a mix of accessible and inaccessible models
+    accessible_model = MagicMock(can_access=True, id=uuid4())
+    inaccessible_model = MagicMock(can_access=False, id=uuid4())
+    models = [accessible_model, inaccessible_model]
+
+    service.get_space = AsyncMock(return_value=space)
+    service.ai_models_service.get_completion_models = AsyncMock(return_value=models)
+
+    # Verify that attempting to update with inaccessible models raises UnauthorizedException
+    with pytest.raises(UnauthorizedException):
+        await service.update_space(
+            id=TEST_UUID,
+            completion_model_ids=[accessible_model.id, inaccessible_model.id]
+        )

--- a/frontend/apps/web/package.json
+++ b/frontend/apps/web/package.json
@@ -5,7 +5,6 @@
   "type": "module",
   "scripts": {
     "dev": "vite dev --host 0.0.0.0",
-    "dev": "vite dev",
     "build": "NODE_ENV=production vite build",
     "build:all": "pnpm run --recursive --filter @intric/web... build",
     "preview": "vite preview",

--- a/frontend/apps/web/src/lib/features/ai-models/components/SelectModels.svelte
+++ b/frontend/apps/web/src/lib/features/ai-models/components/SelectModels.svelte
@@ -123,14 +123,14 @@
     {:else}
       {#each availableModels as model (model.id)}
         <div
-          class="cursor-pointer border-b border-black/10 py-4 pl-2 pr-4 hover:bg-stone-50"
-      >
-        <Input.Switch
-          value={$currentlySelectedModels.includes(model.id)}
-          sideEffect={() => toggleModel(model)}
+          class="cursor-pointer border-b py-4 pl-2 pr-4 transition-colors hover:[background:var(--background-hover-dimmer)] [border-color:var(--border-default)]"
         >
-          <ModelNameAndVendor {model} />
-        </Input.Switch>
+          <Input.Switch
+            value={$currentlySelectedModels.includes(model.id)}
+            sideEffect={() => toggleModel(model)}
+          >
+            <ModelNameAndVendor {model} />
+          </Input.Switch>
         </div>
       {/each}
     {/if}

--- a/frontend/apps/web/src/lib/features/ai-models/components/SelectModels.svelte
+++ b/frontend/apps/web/src/lib/features/ai-models/components/SelectModels.svelte
@@ -1,0 +1,138 @@
+<!--
+    Copyright (c) 2024 Sundsvalls Kommun
+
+    Licensed under the MIT License.
+-->
+
+<script lang="ts">
+  import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
+  import type { CompletionModel, EmbeddingModel, SecurityLevel } from "@intric/intric-js";
+  import ModelNameAndVendor from "./ModelNameAndVendor.svelte";
+  import { Input } from "@intric/ui";
+  import { derived } from "svelte/store";
+
+  type Model = CompletionModel | EmbeddingModel;
+  type ModelType = "completion" | "embedding";
+
+  export let selectableModels: Model[];
+  export let securityLevels: SecurityLevel[];
+  export let modelType: ModelType;
+  export let title: string;
+  export let description: string;
+
+  selectableModels.sort(sortModel);
+
+  function sortModel(a: Model, b: Model) {
+    if (a.org === b.org) {
+      const aName = modelType === "embedding" ? (a as EmbeddingModel).name : (a as CompletionModel).nickname;
+      const bName = modelType === "embedding" ? (b as EmbeddingModel).name : (b as CompletionModel).nickname;
+      return (aName ?? "a") > (bName ?? "b") ? 1 : -1;
+    }
+    return (a.org ?? "a") > (b.org ?? "b") ? 1 : -1;
+  }
+
+  const {
+    state: { currentSpace },
+    updateSpace
+  } = getSpacesManager();
+
+  function modelHasHighEnoughSecurityLevel(model: Model) {
+    const spaceSecurityLevel = $currentSpace.security_level?.value ?? 0;
+    if (!spaceSecurityLevel) return true;
+
+    const modelSecurityLevel = securityLevels.find((level) => level.id === model.security_level_id)?.value ?? 0;
+    return modelSecurityLevel >= spaceSecurityLevel;
+  }
+
+  function getAvailableModels() {
+    return selectableModels.filter((model) => modelHasHighEnoughSecurityLevel(model));
+  }
+
+  $: availableModels = getAvailableModels();
+
+  $: {
+    // This block will re-run whenever $currentSpace changes
+    $currentSpace;
+    availableModels = getAvailableModels();
+  }
+
+  const currentlySelectedModels = derived(
+    currentSpace,
+    ($currentSpace) => modelType === "embedding"
+      ? $currentSpace.embedding_models.map((model) => model.id) ?? []
+      : $currentSpace.completion_models.map((model) => model.id) ?? []
+  );
+
+  let loading = new Set<string>();
+  async function toggleModel(model: Model) {
+    loading.add(model.id);
+    loading = loading;
+
+    try {
+      const newModels = $currentlySelectedModels.includes(model.id)
+        ? $currentlySelectedModels.filter((id) => id !== model.id)
+        : [...$currentlySelectedModels, model.id];
+
+      const updateData = {
+        [modelType === "embedding" ? "embedding_models" : "completion_models"]: newModels.map((id) => ({ id })),
+        security_level_id: $currentSpace.security_level?.id
+      };
+
+      await updateSpace(updateData);
+    } catch (e) {
+      alert(e);
+    }
+    loading.delete(model.id);
+    loading = loading;
+  }
+</script>
+
+<div class="flex flex-col gap-4 pb-2 lg:flex-row lg:gap-12">
+  <div class="pl-2 pr-12 lg:w-2/5">
+    <h3 class="pb-1 text-lg font-medium">{title}</h3>
+    <p class="text-stone-500">
+      {description}
+    </p>
+    {#if $currentlySelectedModels.length === 0}
+      <p
+        class="mt-2.5 rounded-md border border-amber-500 bg-amber-50 px-2 py-1 text-sm text-amber-800"
+      >
+        <span class="font-bold">Hint:&nbsp;</span>
+        {#if modelType === "embedding"}
+          Enable an embedding model to be able to use knowledge from collections and websites.
+        {:else}
+          Enable at least one completion model to be able to use assistants.
+        {/if}
+      </p>
+    {:else if modelType === "embedding" && $currentlySelectedModels.length > 1}
+      <p
+        class="mt-2.5 rounded-md border border-amber-500 bg-amber-50 px-2 py-1 text-sm text-amber-800"
+      >
+        <span class="font-bold">Hint:&nbsp;</span>We strongly recommend to only activate one
+        embedding model per space. Data embedded with different models is not compatible with each
+        other.
+      </p>
+    {/if}
+  </div>
+
+  <div class="flex flex-grow flex-col">
+    {#if availableModels.length === 0}
+      <p class="mt-2.5 rounded-md border border-amber-500 bg-amber-50 px-2 py-1 text-sm text-amber-800">
+        No models available that match this space's security level <span class="font-bold">{ $currentSpace.security_level?.name }</span>.
+      </p>
+    {:else}
+      {#each availableModels as model (model.id)}
+        <div
+          class="cursor-pointer border-b border-black/10 py-4 pl-2 pr-4 hover:bg-stone-50"
+      >
+        <Input.Switch
+          value={$currentlySelectedModels.includes(model.id)}
+          sideEffect={() => toggleModel(model)}
+        >
+          <ModelNameAndVendor {model} />
+        </Input.Switch>
+        </div>
+      {/each}
+    {/if}
+  </div>
+</div>

--- a/frontend/apps/web/src/lib/features/spaces/SpacesManager.ts
+++ b/frontend/apps/web/src/lib/features/spaces/SpacesManager.ts
@@ -101,6 +101,7 @@ function SpacesManager(data: SpacesManagerParams) {
     space?: { id: string } | undefined
   ) {
     const { id } = space ?? get(currentSpace);
+
     try {
       const updatedSpace = await intric.spaces.update({ space: { id }, update });
       userSpaces.update((spaces) => {
@@ -117,6 +118,19 @@ function SpacesManager(data: SpacesManagerParams) {
       return updatedSpace;
     } catch (e) {
       alert(`Error updating space ${id}`);
+      console.error(e);
+    }
+  }
+
+  async function updateSpaceDryrun(
+    update: Parameters<typeof intric.spaces.updateDryrun>[0]["update"],
+    space?: { id: string } | undefined
+  ) {
+    const { id } = space ?? get(currentSpace);
+    try {
+      const updatedSpace = await intric.spaces.updateDryrun({ space: { id }, update });
+      return updatedSpace;
+    } catch (e) {
       console.error(e);
     }
   }
@@ -163,6 +177,7 @@ function SpacesManager(data: SpacesManagerParams) {
     refreshCurrentSpace,
     createSpace,
     updateSpace,
+    updateSpaceDryrun,
     deleteSpace,
     watchPageData,
     updateDefaultAssistant

--- a/frontend/apps/web/src/routes/(app)/admin/AdminMenu.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/AdminMenu.svelte
@@ -16,6 +16,7 @@
   import { getAppContext } from "$lib/core/AppContext";
   import { Navigation } from "$lib/components/layout";
   import { IconStorage } from "@intric/icons/storage";
+  import { IconKey } from "@intric/icons/key";
 
   let currentRoute = "";
   $: currentRoute = $page.url.pathname;
@@ -75,7 +76,12 @@
       icon: IconStorage,
       label: "Storage",
       url: "/admin/storage"
-    }
+    },
+    {
+      icon: IconKey,
+      label: "Security Levels",
+      url: "/admin/security-levels"
+    },
   ];
 
   function isSelected(url: string, currentRoute: string) {

--- a/frontend/apps/web/src/routes/(app)/admin/models/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/+page.svelte
@@ -26,10 +26,10 @@
   </Page.Header>
   <Page.Main>
     <Page.Tab id="completion_models">
-      <CompletionModelsTable completionModels={data.models.completionModels} />
+      <CompletionModelsTable completionModels={data.models.completionModels} securityLevels={data.securityLevels} />
     </Page.Tab>
     <Page.Tab id="embedding_models">
-      <EmbeddingModelsTable embeddingModels={data.models.embeddingModels} />
+      <EmbeddingModelsTable embeddingModels={data.models.embeddingModels} securityLevels={data.securityLevels} />
     </Page.Tab>
   </Page.Main>
 </Page.Root>

--- a/frontend/apps/web/src/routes/(app)/admin/models/+page.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/models/+page.ts
@@ -9,9 +9,11 @@ export const load = async (event) => {
 
   event.depends("admin:models:load");
 
+  const securityLevels = await intric.securityLevels.getSecurityLevels();
   const models = await intric.models.list();
 
   return {
-    models
+    models,
+    securityLevels
   };
 };

--- a/frontend/apps/web/src/routes/(app)/admin/models/CompletionModelsTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/CompletionModelsTable.svelte
@@ -5,10 +5,12 @@
 -->
 
 <script lang="ts">
-  import type { CompletionModel } from "@intric/intric-js";
+  import type { CompletionModel, SecurityLevel } from "@intric/intric-js";
   import { Table } from "@intric/ui";
   import { createRender } from "svelte-headless-table";
-  import ModelEnabledSwitch from "./ModelEnableSwitch.svelte";
+  import ModelEnableSwitch from "./ModelEnableSwitch.svelte";
+  import ModelTile from "./ModelTile.svelte";
+  import ModelSecurityLevelSelect from "./ModelSecurityLevelSelect.svelte";
   import {
     default as ModelLabels,
     getLabels
@@ -18,6 +20,8 @@
   import ModelCardDialog from "$lib/features/ai-models/components/ModelCardDialog.svelte";
 
   export let completionModels: CompletionModel[];
+  export let securityLevels: SecurityLevel[];
+
   const table = Table.createWithResource(completionModels);
 
   const viewModel = table.createViewModel([
@@ -44,9 +48,8 @@
     table.column({
       accessor: (model) => model,
       header: "Enabled",
-      cell: (item) => {
-        return createRender(ModelEnabledSwitch, { model: item.value });
-      },
+      cell: (item) =>
+        createRender(ModelEnableSwitch, { model: item.value, modeltype: "completion" }),
       plugins: {
         sort: {
           getSortValue(value) {
@@ -58,10 +61,18 @@
 
     table.column({
       accessor: (model) => model,
+      header: "Security Level",
+      cell: (item) =>
+        createRender(ModelSecurityLevelSelect, {
+          model: item.value,
+          modeltype: "completion",
+          securityLevels
+        })
+    }),
+    table.column({
+      accessor: (model) => model,
       header: "Details",
-      cell: (item) => {
-        return createRender(ModelLabels, { model: item.value });
-      },
+      cell: (item) => createRender(ModelLabels, { model: item.value }),
       plugins: {
         sort: {
           disable: true
@@ -76,11 +87,14 @@
         }
       }
     }),
-
-    table.columnActions({
-      cell: (item) => {
-        return createRender(ModelActions, { model: item.value });
-      }
+    table.columnCard({
+      value: (item) => item.name,
+      cell: (item) =>
+        createRender(ModelTile, {
+          model: item.value,
+          modeltype: "completion",
+          securityLevels
+        })
     })
   ]);
 

--- a/frontend/apps/web/src/routes/(app)/admin/models/EmbeddingModelsTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/EmbeddingModelsTable.svelte
@@ -5,10 +5,12 @@
 -->
 
 <script lang="ts">
-  import type { EmbeddingModel } from "@intric/intric-js";
+  import type { EmbeddingModel, SecurityLevel } from "@intric/intric-js";
   import { Table } from "@intric/ui";
   import { createRender } from "svelte-headless-table";
   import ModelEnableSwitch from "./ModelEnableSwitch.svelte";
+  import ModelSecurityLevelSelect from "./ModelSecurityLevelSelect.svelte";
+  import ModelTile from "./ModelTile.svelte";
   import {
     default as ModelLabels,
     getLabels
@@ -18,6 +20,8 @@
   import ModelActions from "./ModelActions.svelte";
 
   export let embeddingModels: EmbeddingModel[];
+  export let securityLevels: SecurityLevel[];
+
   const table = Table.createWithResource(embeddingModels);
 
   const viewModel = table.createViewModel([
@@ -44,22 +48,30 @@
       accessor: (model) => model,
       header: "Enabled",
       cell: (item) => {
-        return createRender(ModelEnableSwitch, { model: item.value });
+        return createRender(ModelEnableSwitch, { model: item.value, modeltype: "embedding" });
       },
       plugins: {
         sort: {
           getSortValue(value) {
-            return value.is_org_enabled ? 1 : 0;
+            return value.can_access ? 1 : 0;
           }
         }
       }
     }),
     table.column({
       accessor: (model) => model,
-      header: "Details",
-      cell: (item) => {
-        return createRender(ModelLabels, { model: item.value });
-      },
+      header: "Security Level",
+      cell: (item) =>
+        createRender(ModelSecurityLevelSelect, {
+          model: item.value,
+          modeltype: "embedding",
+          securityLevels
+        })
+    }),
+    table.column({
+      accessor: (model) => model,
+      header: "Labels",
+      cell: (item) => createRender(ModelLabels, { model: item.value }),
       plugins: {
         sort: {
           disable: true
@@ -79,6 +91,15 @@
       cell: (item) => {
         return createRender(ModelActions, { model: item.value });
       }
+    }),
+    table.columnCard({
+      value: (item) => item.name,
+      cell: (item) =>
+        createRender(ModelTile, {
+          model: item.value,
+          modeltype: "embedding",
+          securityLevels
+        })
     })
   ]);
 

--- a/frontend/apps/web/src/routes/(app)/admin/models/ModelSecurityLevelSelect.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/ModelSecurityLevelSelect.svelte
@@ -1,0 +1,115 @@
+<!--
+    Copyright (c) 2025 Sundsvalls Kommun
+
+    Licensed under the MIT License.
+-->
+
+<script lang="ts">
+  import type { SecurityLevel } from "@intric/intric-js";
+  import { invalidate } from "$app/navigation";
+  import { getIntric } from "$lib/core/Intric";
+  import { Select } from "@intric/ui";
+  import { writable, type Writable } from "svelte/store";
+  import type { SelectOption } from "@melt-ui/svelte";
+
+  export let model: {
+    id: string;
+    is_locked?: boolean;
+    security_level_id?: string | null;
+    is_org_enabled?: boolean;
+  };
+  export let modeltype: "completion" | "embedding";
+  export let securityLevels: SecurityLevel[];
+
+  let securityLevel: SecurityLevel | undefined;
+
+  $: if (securityLevels) {
+    securityLevel = securityLevels.find((level) => level.id === model.security_level_id);
+  }
+
+  const intric = getIntric();
+
+  async function updateCompletionModel(
+    completionModel: { id: string },
+    update: { security_level_id?: string | null; is_org_enabled?: boolean }
+  ) {
+    try {
+      await intric.models.update({ completionModel, update });
+      invalidate("admin:models:load");
+    } catch (e) {
+      alert(e);
+      console.error(e);
+    }
+  }
+
+  async function updateEmbeddingModel(
+    embeddingModel: { id: string },
+    update: { security_level_id?: string | null; is_org_enabled?: boolean }
+  ) {
+    try {
+      await intric.models.update({ embeddingModel, update });
+      invalidate("admin:models:load");
+    } catch (e) {
+      alert(e);
+      console.error(e);
+    }
+  }
+
+  async function updateSecurityLevel(levelId: string | null) {
+    if (model.is_locked) return;
+
+    const update = {
+      security_level_id: levelId || undefined,
+      is_org_enabled: model.is_org_enabled ?? false
+    };
+
+    if (modeltype === "completion") {
+      await updateCompletionModel({ id: model.id }, update);
+    } else if (modeltype === "embedding") {
+      await updateEmbeddingModel({ id: model.id }, update);
+    } else {
+      throw new Error("Invalid model type");
+    }
+  }
+
+  $: options = [
+    { value: null, label: "No security level" },
+    ...securityLevels.map(level => ({
+      value: level.id,
+      label: level.name
+    }))
+  ];
+
+  const selectedOption: Writable<SelectOption<string | null>> = writable({
+    value: model.security_level_id ?? null,
+    label: securityLevel?.name ?? "No security level"
+  });
+
+  $: {
+    const currentOption = options.find(opt => opt.value === model.security_level_id);
+    if (currentOption) {
+      selectedOption.set(currentOption);
+    }
+  }
+
+  $: if ($selectedOption?.value !== model.security_level_id) {
+    updateSecurityLevel($selectedOption?.value ?? null);
+  }
+</script>
+
+<div>
+  {#if securityLevels.length === 0}
+    <div class="text-stone-600 text-sm">No security level</div>
+  {:else}
+    <div class="-mb-1.5">
+      <Select.Root customStore={selectedOption} disabled={model.is_locked} class="w-48">
+        <Select.Trigger />
+        <Select.Options>
+          {#each options as option}
+            <Select.Item value={option.value} label={option.label} />
+          {/each}
+        </Select.Options>
+      </Select.Root>
+    </div>
+  {/if}
+</div>

--- a/frontend/apps/web/src/routes/(app)/admin/models/ModelTile.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/ModelTile.svelte
@@ -1,0 +1,62 @@
+<!--
+    Copyright (c) 2024 Sundsvalls Kommun
+
+    Licensed under the MIT License.
+-->
+
+<script lang="ts">
+  import type { CompletionModel, EmbeddingModel, SecurityLevel } from "@intric/intric-js";
+  import ModelEnableSwitch from "./ModelEnableSwitch.svelte";
+  import ModelSecurityLevelSelect from "./ModelSecurityLevelSelect.svelte";
+  import { Label } from "@intric/ui";
+  import { getLabels } from "$lib/features/ai-models/components/ModelLabels.svelte";
+  import ModelNameAndVendor from "$lib/features/ai-models/components/ModelNameAndVendor.svelte";
+
+  export let model: CompletionModel | EmbeddingModel;
+  export let modeltype: "completion" | "embedding";
+  export let securityLevels: SecurityLevel[];
+
+  let labels = getLabels(model);
+</script>
+
+<div
+  class="flex w-[24rem] flex-col rounded-xl border border-b-2 border-default bg-secondary shadow"
+>
+  <div
+    class="-m-[1px] flex flex-grow flex-col rounded-lg border border-default bg-primary shadow-sm"
+  >
+    <div class="flex flex-col gap-2 p-4">
+      <ModelNameAndVendor {model} size="card"></ModelNameAndVendor>
+      <div class="pt-2">
+        {model.description}
+      </div>
+    </div>
+    <div class="h-[1px] bg-hover-default"></div>
+    <div class="flex flex-col items-start px-4 pb-3 pt-1">
+      <Label.List
+        content={[
+          {
+            label: model.name,
+            color: "blue",
+            tooltip: "Full model name"
+          }
+        ]}
+        capitalize={false}
+        monospaced={true}>Full name</Label.List
+      >
+      <Label.List content={labels}>Details</Label.List>
+    </div>
+  </div>
+  <div>
+    <div class="flex h-full flex-col gap-2 px-5 py-4">
+      <div class="flex items-center justify-between">
+        <p>Enabled</p>
+        <ModelEnableSwitch {model} {modeltype} />
+      </div>
+      <div class="flex items-center justify-between">
+        <p>Security Level</p>
+        <ModelSecurityLevelSelect {model} {modeltype} {securityLevels} />
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/apps/web/src/routes/(app)/admin/models/SecurityLevelHeader.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/models/SecurityLevelHeader.svelte
@@ -1,0 +1,14 @@
+<!--
+    Copyright (c) 2024 Sundsvalls Kommun
+
+    Licensed under the MIT License.
+-->
+
+<script lang="ts">
+  import { IconKey } from "@intric/icons/key";
+</script>
+
+<div class="flex items-center gap-2">
+  <IconKey size="sm" />
+  <span>Security Level</span>
+</div>

--- a/frontend/apps/web/src/routes/(app)/admin/security-levels/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/security-levels/+page.svelte
@@ -1,0 +1,28 @@
+<!--
+    Copyright (c) 2024 Sundsvalls Kommun
+
+    Licensed under the MIT License.
+-->
+
+<script lang="ts">
+  import { Page } from "$lib/components/layout/index.js";
+  import SecurityLevelsTable from "./SecurityLevelsTable.svelte";
+  import SecurityLevelDialog from "./SecurityLevelDialog.svelte";
+  export let data;
+
+</script>
+
+<svelte:head>
+  <title>Intric.ai – Admin – Security Levels</title>
+</svelte:head>
+
+
+<Page.Root>
+  <Page.Header>
+    <Page.Title title="Security Levels"></Page.Title>
+    <SecurityLevelDialog></SecurityLevelDialog>
+  </Page.Header>
+  <Page.Main>
+    <SecurityLevelsTable securityLevels={data.securityLevels} />
+  </Page.Main>
+</Page.Root>

--- a/frontend/apps/web/src/routes/(app)/admin/security-levels/+page.ts
+++ b/frontend/apps/web/src/routes/(app)/admin/security-levels/+page.ts
@@ -1,0 +1,10 @@
+import type { PageLoad } from './$types';
+
+export const load: PageLoad = async (event) => {
+  const { intric } = await event.parent();
+  event.depends("admin:security-levels:load");
+  const securityLevels = await intric.securityLevels.getSecurityLevels();
+  return {
+    securityLevels
+  };
+};

--- a/frontend/apps/web/src/routes/(app)/admin/security-levels/SecurityLevelDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/security-levels/SecurityLevelDialog.svelte
@@ -1,0 +1,101 @@
+<script lang="ts">
+  import { invalidate } from "$app/navigation";
+  import { getIntric } from "$lib/core/Intric";
+  import { Button, Dialog, Input } from "@intric/ui";
+  import type { SecurityLevel } from "@intric/intric-js";
+  import { onMount } from "svelte";
+
+  const intric = getIntric();
+
+  export let securityLevel: SecurityLevel | undefined = undefined;
+  export let onComplete = () => {};
+
+  let newSecurityLevelName = "";
+  let newSecurityLevelDescription = "";
+  let newSecurityLevelValue = 0;
+  let isProcessing = false;
+  let showDialog: Dialog.OpenState;
+
+  function initializeFields() {
+    if (securityLevel) {
+      newSecurityLevelName = securityLevel.name;
+      newSecurityLevelDescription = securityLevel.description ?? "";
+      newSecurityLevelValue = securityLevel.value;
+    } else {
+      newSecurityLevelName = "";
+      newSecurityLevelDescription = "";
+      newSecurityLevelValue = 0;
+    }
+  }
+
+  // Initialize fields when securityLevel changes
+  $: if ($showDialog) {
+    initializeFields();
+  }
+
+  onMount(() => {
+    initializeFields();
+  });
+
+  async function handleSubmit() {
+    if (newSecurityLevelName === "") return;
+    isProcessing = true;
+
+    try {
+      if (securityLevel) {
+        await intric.securityLevels.updateSecurityLevel(securityLevel.id, {
+          name: newSecurityLevelName,
+          description: newSecurityLevelDescription,
+          value: newSecurityLevelValue
+        });
+      } else {
+        await intric.securityLevels.createSecurityLevel({
+          name: newSecurityLevelName,
+          description: newSecurityLevelDescription,
+          value: newSecurityLevelValue
+        });
+      }
+
+      invalidate("admin:security-levels:load");
+      $showDialog = false;
+      newSecurityLevelName = "";
+      newSecurityLevelDescription = "";
+      newSecurityLevelValue = 0;
+      onComplete();
+    } catch (e) {
+      alert(`Error ${securityLevel ? "updating" : "creating"} security level`);
+      console.error(e);
+    }
+    isProcessing = false;
+  }
+</script>
+
+<Dialog.Root alert bind:isOpen={showDialog}>
+  <Dialog.Trigger asFragment let:trigger>
+    <slot {trigger}>
+      <Button is={trigger} variant={securityLevel ? "primary-outlined" : "primary"}>{securityLevel ? "Edit" : "Create security level"}</Button>
+    </slot>
+  </Dialog.Trigger>
+  <Dialog.Content wide form>
+    <Dialog.Title>{securityLevel ? "Edit" : "Create"} security level</Dialog.Title>
+
+    <Dialog.Section>
+      <Input.Text
+        bind:value={newSecurityLevelName}
+        required
+        class="border-b border-stone-100 px-4 py-4 hover:bg-stone-50">Name</Input.Text>
+      <Input.Text bind:value={newSecurityLevelDescription} required class="border-b border-stone-100 px-4 py-4 hover:bg-stone-50">Description</Input.Text>
+      <Input.Number bind:value={newSecurityLevelValue} required class="border-b border-stone-100 px-4 py-4 hover:bg-stone-50">Value</Input.Number>
+    </Dialog.Section>
+
+    <Dialog.Controls let:close>
+      <Button is={close}>Cancel</Button>
+      <Button
+        variant="primary"
+        on:click={handleSubmit}
+        disabled={isProcessing}
+        >{isProcessing ? (securityLevel ? "Updating..." : "Creating...") : (securityLevel ? "Update security level" : "Create security level")}</Button
+      >
+    </Dialog.Controls>
+  </Dialog.Content>
+</Dialog.Root>

--- a/frontend/apps/web/src/routes/(app)/admin/security-levels/SecurityLevelsTable.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/security-levels/SecurityLevelsTable.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+    import { Button, Table } from "@intric/ui";
+    import { createRender } from "svelte-headless-table";
+    import type { SecurityLevel } from "@intric/intric-js";
+    import SecurityLevelsTableRowActions from "./SecurityLevelsTableRowActions.svelte";
+
+    export let securityLevels: SecurityLevel[] = [];
+
+    const table = Table.createWithResource(securityLevels);
+
+    const viewModel = table.createViewModel([
+        table.column({ accessor: "name", header: "Name" }),
+        table.column({ accessor: "value", header: "Value" }),
+        table.column({ accessor: "description", header: "Description" }),
+        table.columnActions({ cell: (row) => {
+          return createRender(SecurityLevelsTableRowActions, {
+            securityLevel: row.value
+          });
+        }
+        }),
+    ]);
+
+    $: table.update(securityLevels);
+</script>
+
+<Table.Root {viewModel} resourceName="security-level" displayAs="list">
+  <Table.Group />
+</Table.Root>

--- a/frontend/apps/web/src/routes/(app)/admin/security-levels/SecurityLevelsTableRowActions.svelte
+++ b/frontend/apps/web/src/routes/(app)/admin/security-levels/SecurityLevelsTableRowActions.svelte
@@ -1,0 +1,53 @@
+<script lang="ts">
+  import { Button, Dialog } from "@intric/ui";
+  import type { SecurityLevel } from "@intric/intric-js";
+  import { getIntric } from "$lib/core/Intric";
+  import { invalidate } from "$app/navigation";
+  import SecurityLevelDialog from "./SecurityLevelDialog.svelte";
+
+  const intric = getIntric();
+
+  export let securityLevel: SecurityLevel;
+
+  let isDeleting = false;
+  let showDeleteDialog: Dialog.OpenState;
+
+  async function deleteSecurityLevel() {
+    isDeleting = true;
+    try {
+      await intric.securityLevels.deleteSecurityLevel(securityLevel.id);
+      invalidate("admin:security-levels:load");
+      $showDeleteDialog = false;
+    } catch (e) {
+      alert("Could not delete security level.");
+      console.error(e);
+    }
+    isDeleting = false;
+  }
+</script>
+
+<div class="flex gap-2">
+  <SecurityLevelDialog {securityLevel}></SecurityLevelDialog>
+
+  <Dialog.Root alert bind:isOpen={showDeleteDialog}>
+    <Dialog.Trigger asFragment let:trigger>
+      <Button is={trigger} destructive label="Delete">
+        <span>Delete</span>
+      </Button>
+    </Dialog.Trigger>
+
+    <Dialog.Content>
+      <Dialog.Title>Delete security level</Dialog.Title>
+      <Dialog.Description>
+        Do you really want to delete <span class="italic">{securityLevel.name}</span>?
+      </Dialog.Description>
+
+      <Dialog.Controls let:close>
+        <Button is={close}>Cancel</Button>
+        <Button disabled={isDeleting} destructive on:click={deleteSecurityLevel}>
+          {isDeleting ? "Deleting..." : "Delete"}
+        </Button>
+      </Dialog.Controls>
+    </Dialog.Content>
+  </Dialog.Root>
+</div>

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/+page.svelte
@@ -7,13 +7,19 @@
 <script lang="ts">
   import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
   import { Button, Dialog, Input } from "@intric/ui";
-  import SelectEmbeddingModels from "./SelectEmbeddingModels.svelte";
+  import SelectModels from "$lib/features/ai-models/components/SelectModels.svelte";
   import EditNameAndDescription from "./EditNameAndDescription.svelte";
   import SelectCompletionModels from "./SelectCompletionModels.svelte";
   import { Page, Settings } from "$lib/components/layout";
   import SpaceStorageOverview from "./SpaceStorageOverview.svelte";
+  import SelectSecurityLevel from "./SelectSecurityLevel.svelte";
+  import type { SecurityLevel, CompletionModel, EmbeddingModel } from "@intric/intric-js";
 
-  export let data;
+  export let data: {
+    securityLevels: SecurityLevel[],
+    completionModels: CompletionModel[],
+    embeddingModels: EmbeddingModel[]
+  };
 
   const spaces = getSpacesManager();
   const currentSpace = spaces.state.currentSpace;
@@ -23,6 +29,7 @@
   let isDeleting = false;
   let showStillDeletingMessage = false;
   let deletionMessageTimeout: ReturnType<typeof setTimeout>;
+
   async function deleteSpace() {
     if (deleteConfirmation === "") return;
     if (deleteConfirmation !== $currentSpace.name) {
@@ -61,15 +68,31 @@
         <SpaceStorageOverview></SpaceStorageOverview>
       </Settings.Group>
 
-      <Settings.Group title="AI Models">
-        <SelectCompletionModels
-          selectableModels={data.completionModels.filter((model) => model.is_org_enabled)}
-        ></SelectCompletionModels>
+    {#if $currentSpace.permissions?.includes("edit")}
+      <section>
+        <SelectSecurityLevel securityLevels={data.securityLevels} embeddingModels={data.embeddingModels} completionModels={data.completionModels} />
+      </section>
+    {/if}
 
-        <SelectEmbeddingModels
-          selectableModels={data.embeddingModels.filter((model) => model.is_org_enabled)}
-        ></SelectEmbeddingModels>
-      </Settings.Group>
+    <section class="relative">
+      <div class="relative flex flex-col gap-8 py-5 pr-6 lg:gap-12">
+        <SelectModels
+          selectableModels={data.completionModels.filter((model) => model.can_access)}
+          securityLevels={data.securityLevels}
+          modelType="completion"
+          title="Completion Models"
+          description="Choose which completion models will be available to the applications in this space."
+        />
+
+        <SelectModels
+          selectableModels={data.embeddingModels.filter((model) => model.can_access)}
+          securityLevels={data.securityLevels}
+          modelType="embedding"
+          title="Embedding Models"
+          description="Choose which embedding models will be available to embed data in this space."
+        />
+      </div>
+    </section>
 
       {#if $currentSpace.permissions?.includes("delete")}
         <Settings.Group title="Danger zone">

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/+page.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/+page.svelte
@@ -77,7 +77,7 @@
     <section class="relative">
       <div class="relative flex flex-col gap-8 py-5 pr-6 lg:gap-12">
         <SelectModels
-          selectableModels={data.completionModels.filter((model) => model.can_access)}
+          selectableModels={data.completionModels.filter((model) => model.is_org_enabled)}
           securityLevels={data.securityLevels}
           modelType="completion"
           title="Completion Models"
@@ -85,7 +85,7 @@
         />
 
         <SelectModels
-          selectableModels={data.embeddingModels.filter((model) => model.can_access)}
+          selectableModels={data.embeddingModels.filter((model) => model.is_org_enabled)}
           securityLevels={data.securityLevels}
           modelType="embedding"
           title="Embedding Models"

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/+page.ts
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/+page.ts
@@ -8,6 +8,10 @@ export const load = async (event) => {
   const { intric } = await event.parent();
 
   const models = await intric.models.list();
+  const securityLevels = await intric.securityLevels.getSecurityLevels();
 
-  return models;
+  return {
+    ...models,
+    securityLevels
+  };
 };

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SecurityLevelChangeDialog.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SecurityLevelChangeDialog.svelte
@@ -1,0 +1,106 @@
+<!--
+    Copyright (c) 2024 Sundsvalls Kommun
+
+    Licensed under the MIT License.
+-->
+
+<script lang="ts">
+  import type { SecurityLevel, SpaceUpdateDryRunResponse } from "@intric/intric-js";
+  import { Dialog } from "@intric/ui";
+
+  export let isOpen: Dialog.OpenState;
+  export let currentSecurityLevel: SecurityLevel | undefined;
+  export let newSecurityLevel: SecurityLevel | undefined;
+  export let dryRunResult: SpaceUpdateDryRunResponse | undefined;
+  export let onConfirm: () => void;
+  export let onCancel: () => void;
+</script>
+
+<Dialog.Root alert bind:isOpen>
+  <Dialog.Content>
+    <Dialog.Title>Change Security Level</Dialog.Title>
+    <Dialog.Description hidden>Change the security level of the space</Dialog.Description>
+
+    <Dialog.Section>
+      {#if dryRunResult?.unavailable_completion_models?.length || dryRunResult?.unavailable_embedding_models?.length}
+        <div class="rounded-md border border-amber-200 bg-amber-50 p-4">
+          <div class="flex items-start">
+            <svg class="h-5 w-5 text-amber-400" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M8.485 2.495c.673-1.167 2.357-1.167 3.03 0l6.28 10.875c.673 1.167-.17 2.625-1.516 2.625H3.72c-1.347 0-2.189-1.458-1.515-2.625L8.485 2.495zM10 5a.75.75 0 01.75.75v3.5a.75.75 0 01-1.5 0v-3.5A.75.75 0 0110 5zm0 9a1 1 0 100-2 1 1 0 000 2z" clip-rule="evenodd" />
+            </svg>
+            <div class="ml-3">
+              <h4 class="text-sm font-medium text-amber-800">Security Level Change</h4>
+              <div class="mt-2 text-sm text-amber-700">
+                <p class="mb-3">
+                  You are about to change the security level from
+                  <span class="font-medium">{currentSecurityLevel?.name || "None"}</span>
+                  to
+                  <span class="font-medium">{newSecurityLevel?.name || "None"}</span>.
+                </p>
+                {#if dryRunResult?.unavailable_completion_models?.length || dryRunResult?.unavailable_embedding_models?.length}
+                  <p class="mb-3">Some models do not meet the new security level requirements and will be disabled.</p>
+                {/if}
+                {#if dryRunResult?.unavailable_completion_models?.length}
+                  <div class="ml-1">
+                    <p class="mb-1">Completion models:</p>
+                    <ul class="list-disc space-y-1 pl-5">
+                      {#each dryRunResult.unavailable_completion_models as model}
+                        <li class="font-medium">{model.org}: {model.name}</li>
+                      {/each}
+                    </ul>
+                  </div>
+                {/if}
+                {#if dryRunResult?.unavailable_embedding_models?.length}
+                  <div class="mt-2 ml-1">
+                    <p class="mb-1">Embedding models:</p>
+                    <ul class="list-disc space-y-1 pl-5">
+                      {#each dryRunResult.unavailable_embedding_models as model}
+                        <li class="font-medium">{model.org}: {model.name}</li>
+                      {/each}
+                    </ul>
+                  </div>
+                {/if}
+              </div>
+            </div>
+          </div>
+        </div>
+      {:else}
+        <div class="rounded-md border border-blue-200 bg-blue-50 p-4">
+          <div class="flex items-start">
+            <svg class="h-5 w-5 text-blue-400" viewBox="0 0 20 20" fill="currentColor">
+              <path fill-rule="evenodd" d="M18 10a8 8 0 11-16 0 8 8 0 0116 0zm-7-4a1 1 0 11-2 0 1 1 0 012 0zM9 9a.75.75 0 000 1.5h.253a.25.25 0 01.244.304l-.459 2.066A1.75 1.75 0 0010.747 15H11a.75.75 0 000-1.5h-.253a.25.25 0 01-.244-.304l.459-2.066A1.75 1.75 0 009.253 9H9z" clip-rule="evenodd" />
+            </svg>
+            <div class="ml-3">
+              <h4 class="text-sm font-medium text-blue-800">Security Level Change</h4>
+              <div class="mt-2 text-sm text-blue-700">
+                <p>
+                  You are about to change the security level from
+                  <span class="font-medium">{currentSecurityLevel?.name || "None"}</span>
+                  to
+                  <span class="font-medium">{newSecurityLevel?.name || "None"}</span>.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+      {/if}
+    </Dialog.Section>
+
+    <Dialog.Controls let:close>
+      <button
+        type="button"
+        class="rounded-md bg-white px-3 py-2 text-sm font-semibold text-gray-900 shadow-sm ring-1 ring-inset ring-gray-300 hover:bg-gray-50"
+        on:click={onCancel}
+      >
+        Cancel
+      </button>
+      <button
+        type="button"
+        class="rounded-md bg-blue-600 px-3 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-600"
+        on:click={onConfirm}
+      >
+        Confirm Change
+      </button>
+    </Dialog.Controls>
+  </Dialog.Content>
+</Dialog.Root>

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SelectSecurityLevel.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SelectSecurityLevel.svelte
@@ -1,0 +1,150 @@
+<!--
+    Copyright (c) 2024 Sundsvalls Kommun
+
+    Licensed under the MIT License.
+-->
+
+<script lang="ts">
+  import { getSpacesManager } from "$lib/features/spaces/SpacesManager";
+  import type { CompletionModel, EmbeddingModel, SecurityLevel, SpaceUpdateDryRunResponse } from "@intric/intric-js";
+  import { Dialog } from "@intric/ui";
+  import SecurityLevelChangeDialog from "./SecurityLevelChangeDialog.svelte";
+
+  export let securityLevels: SecurityLevel[];
+  export let embeddingModels: EmbeddingModel[];
+  export let completionModels: CompletionModel[];
+
+  const {
+    state: { currentSpace },
+    updateSpace,
+    refreshCurrentSpace,
+    updateSpaceDryrun
+  } = getSpacesManager();
+
+  let securityLevel: SecurityLevel | undefined;
+  $: if (securityLevels) {
+    securityLevel = securityLevels.find(level => level.id === $currentSpace.security_level?.id);
+  }
+
+  let isUpdating = false;
+  let showConfirmDialog: Dialog.OpenState;
+  let pendingSecurityLevel: SecurityLevel | undefined;
+  let dryRunResult: SpaceUpdateDryRunResponse | undefined;
+
+  // Prepare options for RadioGroup
+  $: radioOptions = [
+    { value: undefined, label: "No security level" },
+    ...securityLevels.map(level => ({ value: level, label: level.name }))
+  ];
+
+  async function updateSecurityLevel(levelId: string | null) {
+    try {
+      isUpdating = true;
+      await updateSpace({ security_level_id: levelId });
+      await refreshCurrentSpace();
+    } catch (e) {
+      console.error("Error updating security level", e);
+      alert("Failed to update security level");
+    } finally {
+      isUpdating = false;
+    }
+  }
+
+  async function handleSecurityLevelChange(level: SecurityLevel | undefined) {
+    if (isUpdating || level === securityLevel) return;
+
+    pendingSecurityLevel = level;
+    try {
+      dryRunResult = await updateSpaceDryrun({
+        security_level_id: level?.id ?? null
+      });
+      $showConfirmDialog = true;
+    } catch (error) {
+      console.error("Error running security level change dry run:", error);
+      alert("Failed to check security level change implications");
+    }
+  }
+
+  function handleConfirmChange() {
+    $showConfirmDialog = false;
+    updateSecurityLevel(pendingSecurityLevel?.id ?? null);
+    securityLevel = pendingSecurityLevel;
+  }
+
+  function handleCancelChange() {
+    $showConfirmDialog = false;
+    pendingSecurityLevel = securityLevel;
+  }
+
+  function hasModelWithIncompatibleSecurityLevel<T extends { id: string }>(
+    spaceModels: Array<T>,
+    allModels: Array<{ id: string; security_level_id?: string | null }>,
+    currentSecurityLevel: SecurityLevel
+  ): boolean {
+    return spaceModels.some(spaceModel => {
+      const model = allModels.find(m => m.id === spaceModel.id);
+      if (!model) return false;
+      const modelSecurityLevel = securityLevels.find(level => level.id === model.security_level_id)?.value ?? 0;
+      return modelSecurityLevel < currentSecurityLevel.value;
+    });
+  }
+
+  function hasIncompatibleModels(currentSecurityLevel: SecurityLevel): boolean {
+    if (!currentSecurityLevel) return false;
+
+    return (
+      hasModelWithIncompatibleSecurityLevel($currentSpace.completion_models, completionModels, currentSecurityLevel) ||
+      hasModelWithIncompatibleSecurityLevel($currentSpace.embedding_models, embeddingModels, currentSecurityLevel)
+    );
+  }
+</script>
+
+<SecurityLevelChangeDialog
+  bind:isOpen={showConfirmDialog}
+  currentSecurityLevel={securityLevel}
+  newSecurityLevel={pendingSecurityLevel}
+  {dryRunResult}
+  onConfirm={handleConfirmChange}
+  onCancel={handleCancelChange}
+/>
+
+<div class="flex flex-col gap-4 py-5 pr-6 lg:flex-row lg:gap-12">
+  <div class="pl-2 pr-12 lg:w-2/5">
+    <h3 class="pb-1 text-lg font-medium">Security Level</h3>
+    <p class="text-stone-500">Set the security level for this space and all its resources.</p>
+    {#if securityLevel && hasIncompatibleModels(securityLevel)}
+      <p class="mt-2.5 rounded-md border border-amber-500 bg-amber-50 px-2 py-1 text-sm text-amber-800">
+        <span class="font-bold">Warning:&nbsp;</span>Some AI models don't meet the selected security level and will be unavailable.
+      </p>
+    {/if}
+  </div>
+  <div class="flex-grow min-w-0 w-full lg:pl-12 lg:max-w-[60%]">
+    <div class="overflow-hidden rounded-lg border border-stone-300 bg-white shadow">
+      <div class="cursor-pointer border-b border-stone-200 last:border-b-0">
+        <div class="px-4 py-3 font-medium">Security level</div>
+        <div class="flex flex-col">
+          {#each radioOptions as option}
+            <label class="flex cursor-pointer flex-col border-t border-stone-200 px-4 py-3 hover:bg-stone-50">
+              <div class="flex items-center gap-3">
+                <input
+                  type="radio"
+                  name="security-level"
+                  class="h-4 w-4 cursor-pointer text-blue-600"
+                  checked={option.value === (pendingSecurityLevel ?? securityLevel)}
+                  disabled={isUpdating}
+                  on:change={() => handleSecurityLevelChange(option.value)}
+                />
+                <span class="font-medium">{option.label}</span>
+              </div>
+              {#if option.value?.description}
+                <p class="mt-1 ml-7 text-sm text-stone-500 break-words">{option.value.description}</p>
+              {:else if !option.value}
+                <p class="mt-1 ml-7 text-sm text-stone-500 break-words">No specific security requirements for this space.</p>
+              {/if}
+            </label>
+          {/each}
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SelectSecurityLevel.svelte
+++ b/frontend/apps/web/src/routes/(app)/spaces/[spaceId]/settings/SelectSecurityLevel.svelte
@@ -111,25 +111,25 @@
 <div class="flex flex-col gap-4 py-5 pr-6 lg:flex-row lg:gap-12">
   <div class="pl-2 pr-12 lg:w-2/5">
     <h3 class="pb-1 text-lg font-medium">Security Level</h3>
-    <p class="text-stone-500">Set the security level for this space and all its resources.</p>
+    <p class="text-secondary">Set the security level for this space and all its resources.</p>
     {#if securityLevel && hasIncompatibleModels(securityLevel)}
-      <p class="mt-2.5 rounded-md border border-amber-500 bg-amber-50 px-2 py-1 text-sm text-amber-800">
+      <p class="mt-2.5 rounded-md border border-warning-default bg-warning-dimmer px-2 py-1 text-sm text-warning-stronger">
         <span class="font-bold">Warning:&nbsp;</span>Some AI models don't meet the selected security level and will be unavailable.
       </p>
     {/if}
   </div>
   <div class="flex-grow min-w-0 w-full lg:pl-12 lg:max-w-[60%]">
-    <div class="overflow-hidden rounded-lg border border-stone-300 bg-white shadow">
-      <div class="cursor-pointer border-b border-stone-200 last:border-b-0">
+    <div class="overflow-hidden rounded-lg border border-default bg-primary shadow">
+      <div class="cursor-pointer border-b border-default last:border-b-0">
         <div class="px-4 py-3 font-medium">Security level</div>
         <div class="flex flex-col">
           {#each radioOptions as option}
-            <label class="flex cursor-pointer flex-col border-t border-stone-200 px-4 py-3 hover:bg-stone-50">
+            <label class="flex cursor-pointer flex-col border-t border-default px-4 py-3 hover:bg-hover-dimmer">
               <div class="flex items-center gap-3">
                 <input
                   type="radio"
                   name="security-level"
-                  class="h-4 w-4 cursor-pointer text-blue-600"
+                  class="h-4 w-4 cursor-pointer text-accent-default"
                   checked={option.value === (pendingSecurityLevel ?? securityLevel)}
                   disabled={isUpdating}
                   on:change={() => handleSecurityLevelChange(option.value)}
@@ -137,9 +137,9 @@
                 <span class="font-medium">{option.label}</span>
               </div>
               {#if option.value?.description}
-                <p class="mt-1 ml-7 text-sm text-stone-500 break-words">{option.value.description}</p>
+                <p class="mt-1 ml-7 text-sm text-secondary break-words">{option.value.description}</p>
               {:else if !option.value}
-                <p class="mt-1 ml-7 text-sm text-stone-500 break-words">No specific security requirements for this space.</p>
+                <p class="mt-1 ml-7 text-sm text-secondary break-words">No specific security requirements for this space.</p>
               {/if}
             </label>
           {/each}

--- a/frontend/packages/intric-js/src/endpoints/security-levels.js
+++ b/frontend/packages/intric-js/src/endpoints/security-levels.js
@@ -1,0 +1,60 @@
+/**
+ * @typedef {Object} SecurityLevel
+ * @property {string} id
+ * @property {string} name
+ * @property {string | null} description
+ * @property {number} value
+ */
+
+/**
+ * @param {import('../client/client').Client} client Provide a client with which to call the endpoints
+ */
+export function initSecurityLevels(client) {
+  return {
+    /**
+     * Get all security levels
+     * @returns {Promise<SecurityLevel[]>}
+     */
+    getSecurityLevels: async () => {
+      const res = await client.fetch("/api/v1/security-levels", {
+        method: "get"
+      });
+      return res;
+    },
+
+    /**
+     * Create a new security level
+     * @param {Omit<SecurityLevel, 'id'>} securityLevel
+     * @returns {Promise<SecurityLevel>}
+     */
+    createSecurityLevel: (securityLevel) =>
+      client.fetch("/api/v1/security-levels", {
+        method: "post",
+        requestBody: { "application/json": securityLevel }
+      }),
+
+    /**
+     * Update a security level
+     * @param {string} id
+     * @param {Partial<Omit<SecurityLevel, 'id'>>} securityLevel
+     * @returns {Promise<SecurityLevel>}
+     */
+    updateSecurityLevel: (id, securityLevel) =>
+      client.fetch(`/api/v1/security-levels/{id}`, {
+        method: "patch",
+        params: { path: { id } },
+        requestBody: { "application/json": securityLevel }
+      }),
+
+    /**
+     * Delete a security level
+     * @param {string} id
+     * @returns {Promise<void>}
+     */
+    deleteSecurityLevel: (id) =>
+      client.fetch(`/api/v1/security-levels/{id}`, {
+        method: "delete",
+        params: { path: { id } }
+      })
+  };
+}

--- a/frontend/packages/intric-js/src/endpoints/spaces.js
+++ b/frontend/packages/intric-js/src/endpoints/spaces.js
@@ -1,4 +1,5 @@
 /** @typedef {import('../types/resources').Space} Space */
+/** @typedef {import('../types/schema').components['schemas']['SpaceUpdateDryRunResponse']} SpaceUpdateDryRunResponse */
 /** @typedef {import('../client/client').IntricError} IntricError */
 
 /**
@@ -101,6 +102,24 @@ export function initSpaces(client) {
       const { id } = space;
       const res = await client.fetch("/api/v1/spaces/{id}/", {
         method: "patch",
+        params: { path: { id } },
+        requestBody: { "application/json": update }
+      });
+      return res;
+    },
+
+    /**
+     * Dry run an update to a space to check what would change.
+     * @param {Object} params
+     * @param {{id: string}} params.space The space you want to test updating
+     * @param {import('../types/fetch').JSONRequestBody<"post", "/api/v1/spaces/{id}/update/dryrun/">} params.update - The parameters to test updating
+     * @returns {Promise<SpaceUpdateDryRunResponse>} The hypothetical updated space
+     * @throws {IntricError}
+     * */
+    updateDryrun: async ({ space, update }) => {
+      const { id } = space;
+      const res = await client.fetch("/api/v1/spaces/{id}/update/dryrun/", {
+        method: "post",
         params: { path: { id } },
         requestBody: { "application/json": update }
       });

--- a/frontend/packages/intric-js/src/intric.js
+++ b/frontend/packages/intric-js/src/intric.js
@@ -21,7 +21,7 @@ import { initPrompts } from "./endpoints/prompts";
 import { initApps } from "./endpoints/apps";
 import { initTemplates } from "./endpoints/templates";
 import { initStorage } from "./endpoints/storage";
-
+import { initSecurityLevels } from "./endpoints/security-levels";
 /**
  * Create an Intric.js object to interact with the intric backend.
  * Requires either an api key or a user token to authenticate requests.
@@ -56,6 +56,7 @@ export function createIntric(args) {
     prompts: initPrompts(client),
     templates: initTemplates(client),
     storage: initStorage(client),
+    securityLevels: initSecurityLevels(client),
     client
   };
 }

--- a/frontend/packages/intric-js/src/types/resources.d.ts
+++ b/frontend/packages/intric-js/src/types/resources.d.ts
@@ -62,6 +62,8 @@ export type AppTemplate = components["schemas"]["AppTemplatePublic"];
 export type TemplateAdditionalField = components["schemas"]["AdditionalField"];
 export type SpaceRole = components["schemas"]["SpaceRole"];
 export type StorageSpaceInfo = components["schemas"]["StorageSpaceInfoModel"];
+export type SecurityLevel = components["schemas"]["SecurityLevelPublic"];
+export type SpaceUpdateDryRunResponse = components["schemas"]["SpaceUpdateDryRunResponse"];
 
 export type Paginated<T> = {
   items: T[];

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -475,12 +475,6 @@ export interface paths {
     /** Enable Embedding Model */
     post: operations["enable_embedding_model_api_v1_embedding_models__id___post"];
   };
-  "/api/v1/embedding-models/{id}/security-level": {
-    /** Set Embedding Model Security Level */
-    put: operations["set_embedding_model_security_level_api_v1_embedding_models__id__security_level_put"];
-    /** Unset Embedding Model Security Level */
-    delete: operations["unset_embedding_model_security_level_api_v1_embedding_models__id__security_level_delete"];
-  };
   "/api/v1/files/": {
     /** Get Files */
     get: operations["get_files_api_v1_files__get"];
@@ -1745,14 +1739,6 @@ export interface components {
       /** Description */
       description?: string | null;
       org?: components["schemas"]["Orgs"] | null;
-    };
-    /** EmbeddingModelSecurityLevelUpdate */
-    EmbeddingModelSecurityLevelUpdate: {
-      /**
-       * Security Level Id
-       * Format: uuid
-       */
-      security_level_id: string;
     };
     /** EmbeddingModelSparse */
     EmbeddingModelSparse: {
@@ -3302,9 +3288,9 @@ export interface components {
      */
     SpaceUpdateDryRunResponse: {
       /** Unavailable Completion Models */
-      unavailable_completion_models: components["schemas"]["CompletionModelSparse"][];
+      unavailable_completion_models: components["schemas"]["CompletionModelPublic"][];
       /** Unavailable Embedding Models */
-      unavailable_embedding_models: components["schemas"]["EmbeddingModelSparse"][];
+      unavailable_embedding_models: components["schemas"]["EmbeddingModelPublic"][];
       current_security_level: components["schemas"]["SecurityLevelSparse"] | null;
       new_security_level: components["schemas"]["SecurityLevelSparse"] | null;
     };
@@ -6885,61 +6871,6 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Set Embedding Model Security Level */
-  set_embedding_model_security_level_api_v1_embedding_models__id__security_level_put: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["EmbeddingModelSecurityLevelUpdate"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["EmbeddingModelPublic"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Unset Embedding Model Security Level */
-  unset_embedding_model_security_level_api_v1_embedding_models__id__security_level_delete: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["EmbeddingModelPublic"];
         };
       };
       /** @description Validation Error */

--- a/frontend/packages/intric-js/src/types/schema.d.ts
+++ b/frontend/packages/intric-js/src/types/schema.d.ts
@@ -26,10 +26,6 @@ export interface paths {
     /** Get Prompts */
     get: operations["get_prompts_api_v1_apps__id__prompts__get"];
   };
-  "/api/v1/apps/{id}/publish/": {
-    /** Publish App */
-    post: operations["publish_app_api_v1_apps__id__publish__post"];
-  };
   "/api/v1/app-runs/{id}/": {
     /** Get App Run */
     get: operations["get_app_run_api_v1_app_runs__id___get"];
@@ -238,14 +234,6 @@ export interface paths {
     /** Transfer Assistant To Space */
     post: operations["transfer_assistant_to_space_api_v1_assistants__id__transfer__post"];
   };
-  "/api/v1/assistants/{id}/prompts/": {
-    /** Get Prompts */
-    get: operations["get_prompts_api_v1_assistants__id__prompts__get"];
-  };
-  "/api/v1/assistants/{id}/publish/": {
-    /** Publish Assistant */
-    post: operations["publish_assistant_api_v1_assistants__id__publish__post"];
-  };
   "/api/v1/services/": {
     /** Get Services */
     get: operations["get_services_api_v1_services__get"];
@@ -363,6 +351,82 @@ export interface paths {
      */
     post: operations["update_privacy_policy_api_v1_admin_privacy_policy__post"];
   };
+  "/api/v1/security-levels": {
+    /**
+     * List Security Levels
+     * @description List all security levels for the current tenant ordered by value.
+     *
+     * Returns:
+     *     List of security levels ordered by value.
+     *
+     * Raises:
+     *     403: If the user doesn't have permission to list security levels.
+     */
+    get: operations["list_security_levels_api_v1_security_levels_get"];
+    /**
+     * Create Security Level
+     * @description Create a new security level for the current tenant.
+     *
+     * Args:
+     *     request: The security level creation request.
+     *
+     * Returns:
+     *     The created security level.
+     *
+     * Raises:
+     *     400: If the request is invalid.
+     *     409: If a security level with the same name already exists for this tenant.
+     */
+    post: operations["create_security_level_api_v1_security_levels_post"];
+  };
+  "/api/v1/security-levels/{id}": {
+    /**
+     * Get Security Level
+     * @description Get a security level by ID.
+     *
+     * Args:
+     *     id: The ID of the security level.
+     *
+     * Returns:
+     *     The security level.
+     *
+     * Raises:
+     *     403: If the user doesn't have permission to view the security level.
+     *     404: If the security level doesn't exist or belongs to a different tenant.
+     */
+    get: operations["get_security_level_api_v1_security_levels__id__get"];
+    /**
+     * Delete Security Level
+     * @description Delete a security level.
+     *
+     * Args:
+     *     id: The ID of the security level to delete.
+     *
+     * Raises:
+     *     403: If the user doesn't have permission to delete the security level.
+     *     404: If the security level doesn't exist or belongs to a different tenant.
+     *     409: If the security level is in use by any spaces or models.
+     */
+    delete: operations["delete_security_level_api_v1_security_levels__id__delete"];
+    /**
+     * Update Security Level
+     * @description Update a security level.
+     *
+     * Args:
+     *     id: The ID of the security level to update.
+     *     request: The update request.
+     *
+     * Returns:
+     *     The updated security level.
+     *
+     * Raises:
+     *     400: If the request is invalid.
+     *     403: If the user doesn't have permission to update the security level.
+     *     404: If the security level doesn't exist or belongs to a different tenant.
+     *     409: If updating the name would create a duplicate within the tenant.
+     */
+    patch: operations["update_security_level_api_v1_security_levels__id__patch"];
+  };
   "/api/v1/jobs/": {
     /** Get Jobs */
     get: operations["get_jobs_api_v1_jobs__get"];
@@ -410,6 +474,12 @@ export interface paths {
   "/api/v1/embedding-models/{id}/": {
     /** Enable Embedding Model */
     post: operations["enable_embedding_model_api_v1_embedding_models__id___post"];
+  };
+  "/api/v1/embedding-models/{id}/security-level": {
+    /** Set Embedding Model Security Level */
+    put: operations["set_embedding_model_security_level_api_v1_embedding_models__id__security_level_put"];
+    /** Unset Embedding Model Security Level */
+    delete: operations["unset_embedding_model_security_level_api_v1_embedding_models__id__security_level_delete"];
   };
   "/api/v1/files/": {
     /** Get Files */
@@ -483,6 +553,15 @@ export interface paths {
     /** Get Personal Space */
     get: operations["get_personal_space_api_v1_spaces_type_personal__get"];
   };
+  "/api/v1/spaces/{id}/update/dryrun/": {
+    /**
+     * Update Space Dryrun
+     * @description Analyze the impact of updating a space's properties without actually applying the changes.
+     * Currently supports:
+     * - Security level changes: Shows which models would be affected
+     */
+    post: operations["update_space_dryrun_api_v1_spaces__id__update_dryrun__post"];
+  };
   "/api/v1/dashboard/": {
     /** Get Dashboard */
     get: operations["get_dashboard_api_v1_dashboard__get"];
@@ -521,39 +600,12 @@ export interface paths {
     /** Get Info Blobs */
     get: operations["get_info_blobs_api_v1_websites__id__info_blobs__get"];
   };
-  "/api/v1/prompts/{id}/": {
-    /** Get Prompt */
-    get: operations["get_prompt_api_v1_prompts__id___get"];
-    /** Delete Prompt */
-    delete: operations["delete_prompt_api_v1_prompts__id___delete"];
-    /** Update Prompt Description */
-    patch: operations["update_prompt_description_api_v1_prompts__id___patch"];
-  };
   "/api/v1/templates/apps/": {
     /**
      * Get Templates
      * @description Get all app templates
      */
     get: operations["get_templates_api_v1_templates_apps__get"];
-    /** Create App Template */
-    post: operations["create_app_template_api_v1_templates_apps__post"];
-  };
-  "/api/v1/templates/apps/admin/": {
-    /**
-     * Get Templates Admin
-     * @description Get all app templates from Admin
-     */
-    get: operations["get_templates_admin_api_v1_templates_apps_admin__get"];
-  };
-  "/api/v1/templates/apps/{id}": {
-    /** Get App Template */
-    get: operations["get_app_template_api_v1_templates_apps__id__get"];
-  };
-  "/api/v1/templates/apps/{id}/": {
-    /** Update App Template */
-    put: operations["update_app_template_api_v1_templates_apps__id___put"];
-    /** Delete App Template */
-    delete: operations["delete_app_template_api_v1_templates_apps__id___delete"];
   };
   "/api/v1/templates/assistants/": {
     /**
@@ -561,23 +613,6 @@ export interface paths {
      * @description Get all assistant templates
      */
     get: operations["get_templates_api_v1_templates_assistants__get"];
-    /** Create Assistant Template */
-    post: operations["create_assistant_template_api_v1_templates_assistants__post"];
-  };
-  "/api/v1/templates/assistants/admin/": {
-    /**
-     * Get Templates Admin
-     * @description Get all assistant templates from Admin
-     */
-    get: operations["get_templates_admin_api_v1_templates_assistants_admin__get"];
-  };
-  "/api/v1/templates/assistants/{id}/": {
-    /** Get Assistant Template */
-    get: operations["get_assistant_template_api_v1_templates_assistants__id___get"];
-    /** Update Assistant Template */
-    put: operations["update_assistant_template_api_v1_templates_assistants__id___put"];
-    /** Delete Assistant Template */
-    delete: operations["delete_assistant_template_api_v1_templates_assistants__id___delete"];
   };
   "/api/v1/templates/": {
     /**
@@ -594,135 +629,17 @@ export interface paths {
     /** Get Spaces */
     get: operations["get_spaces_api_v1_storage_spaces__get"];
   };
-  "/api/v1/widgets/": {
-    /** Get Tenant Widgets */
-    get: operations["get_tenant_widgets_api_v1_widgets__get"];
-    /** Add Widget */
-    post: operations["add_widget_api_v1_widgets__post"];
+  "/api/v1/integrations/": {
+    /** Get Integrations */
+    get: operations["get_integrations_api_v1_integrations__get"];
   };
-  "/api/v1/widgets/{id}/": {
-    /** Get Widget */
-    get: operations["get_widget_api_v1_widgets__id___get"];
-    /** Update Widget */
-    post: operations["update_widget_api_v1_widgets__id___post"];
-    /** Delete Widget */
-    delete: operations["delete_widget_api_v1_widgets__id___delete"];
+  "/api/v1/integrations/tenant/": {
+    /** Get Tenant Integrations */
+    get: operations["get_tenant_integrations_api_v1_integrations_tenant__get"];
   };
-  "/api/v1/widgets/{id}/sessions/": {
-    /** Ask Assistant */
-    post: operations["ask_assistant_api_v1_widgets__id__sessions__post"];
-  };
-  "/api/v1/widgets/{id}/sessions/{session_id}/": {
-    /** Ask Followup */
-    post: operations["ask_followup_api_v1_widgets__id__sessions__session_id___post"];
-  };
-  "/api/v1/widgets/settings/privacy-policy/": {
-    /** Get Privacy Policy */
-    get: operations["get_privacy_policy_api_v1_widgets_settings_privacy_policy__get"];
-    /** Set Privacy Policy */
-    post: operations["set_privacy_policy_api_v1_widgets_settings_privacy_policy__post"];
-  };
-  "/api/v1/sysadmin/users/": {
-    /** Get All Users */
-    get: operations["get_all_users_api_v1_sysadmin_users__get"];
-    /** Register New User */
-    post: operations["register_new_user_api_v1_sysadmin_users__post"];
-  };
-  "/api/v1/sysadmin/users/{user_id}/": {
-    /** Get User */
-    get: operations["get_user_api_v1_sysadmin_users__user_id___get"];
-    /**
-     * Update User
-     * @description Omitted fields are not updated.
-     */
-    post: operations["update_user_api_v1_sysadmin_users__user_id___post"];
-    /** Delete User */
-    delete: operations["delete_user_api_v1_sysadmin_users__user_id___delete"];
-  };
-  "/api/v1/sysadmin/tenants/": {
-    /** Get Tenants */
-    get: operations["get_tenants_api_v1_sysadmin_tenants__get"];
-    /** Create Tenant */
-    post: operations["create_tenant_api_v1_sysadmin_tenants__post"];
-  };
-  "/api/v1/sysadmin/tenants/{id}/": {
-    /** Update Tenant */
-    post: operations["update_tenant_api_v1_sysadmin_tenants__id___post"];
-    /** Delete Tenant By Id */
-    delete: operations["delete_tenant_by_id_api_v1_sysadmin_tenants__id___delete"];
-  };
-  "/api/v1/sysadmin/predefined-roles/": {
-    /** Get Predefined Roles */
-    get: operations["get_predefined_roles_api_v1_sysadmin_predefined_roles__get"];
-  };
-  "/api/v1/sysadmin/crawl-all-weekly-websites/": {
-    /** Crawl All Weekly Websites */
-    post: operations["crawl_all_weekly_websites_api_v1_sysadmin_crawl_all_weekly_websites__post"];
-  };
-  "/api/v1/sysadmin/embedding-models/": {
-    /** Get Embedding Models */
-    get: operations["get_embedding_models_api_v1_sysadmin_embedding_models__get"];
-  };
-  "/api/v1/sysadmin/completion-models/": {
-    /** Get Completion Models */
-    get: operations["get_completion_models_api_v1_sysadmin_completion_models__get"];
-  };
-  "/api/v1/sysadmin/tenants/{id}/completion-models/{completion_model_id}/": {
-    /** Enable Completion Model */
-    post: operations["enable_completion_model_api_v1_sysadmin_tenants__id__completion_models__completion_model_id___post"];
-  };
-  "/api/v1/sysadmin/tenants/{id}/embedding-models/{embedding_model_id}/": {
-    /** Enable Embedding Model */
-    post: operations["enable_embedding_model_api_v1_sysadmin_tenants__id__embedding_models__embedding_model_id___post"];
-  };
-  "/api/v1/sysadmin/spaces/import/": {
-    /** Create Space And Import */
-    post: operations["create_space_and_import_api_v1_sysadmin_spaces_import__post"];
-  };
-  "/api/v1/sysadmin/migrations/migrate-to-spaces/": {
-    /** Migrate To Spaces */
-    post: operations["migrate_to_spaces_api_v1_sysadmin_migrations_migrate_to_spaces__post"];
-  };
-  "/api/v1/sysadmin/allowed-origins/": {
-    /** Get Origins */
-    get: operations["get_origins_api_v1_sysadmin_allowed_origins__get"];
-    /** Add Origin */
-    post: operations["add_origin_api_v1_sysadmin_allowed_origins__post"];
-  };
-  "/api/v1/sysadmin/allowed-origins/{id}/": {
-    /** Delete Origin */
-    delete: operations["delete_origin_api_v1_sysadmin_allowed_origins__id___delete"];
-  };
-  "/api/v1/modules/": {
-    /** Get Modules */
-    get: operations["get_modules_api_v1_modules__get"];
-    /** Add Module */
-    post: operations["add_module_api_v1_modules__post"];
-  };
-  "/api/v1/modules/{tenant_id}/": {
-    /**
-     * Add Module To Tenant
-     * @description Value is a list of module `id`'s to add to the `tenant_id`.
-     */
-    post: operations["add_module_to_tenant_api_v1_modules__tenant_id___post"];
-  };
-  "/api/v1/roles/permissions/": {
-    /** Get Permissions */
-    get: operations["get_permissions_api_v1_roles_permissions__get"];
-  };
-  "/api/v1/roles/": {
-    /** Get Roles */
-    get: operations["get_roles_api_v1_roles__get"];
-    /** Create Role */
-    post: operations["create_role_api_v1_roles__post"];
-  };
-  "/api/v1/roles/{role_id}/": {
-    /** Get Role By Id */
-    get: operations["get_role_by_id_api_v1_roles__role_id___get"];
-    /** Update Role */
-    post: operations["update_role_api_v1_roles__role_id___post"];
-    /** Delete Role By Id */
-    delete: operations["delete_role_by_id_api_v1_roles__role_id___delete"];
+  "/api/v1/integrations/me/": {
+    /** Get User Integrations */
+    get: operations["get_user_integrations_api_v1_integrations_me__get"];
   };
   "/version": {
     /** Get Version */
@@ -765,35 +682,6 @@ export interface components {
         [key: string]: string;
       }[];
     };
-    /** AllowedOriginCreate */
-    AllowedOriginCreate: {
-      /** Url */
-      url: string;
-      /**
-       * Tenant Id
-       * Format: uuid
-       */
-      tenant_id: string;
-    };
-    /** AllowedOriginInDB */
-    AllowedOriginInDB: {
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /**
-       * Id
-       * Format: uuid
-       */
-      id: string;
-      /** Url */
-      url: string;
-      /**
-       * Tenant Id
-       * Format: uuid
-       */
-      tenant_id: string;
-    };
     /** AllowedOriginPublic */
     AllowedOriginPublic: {
       /** Created At */
@@ -814,17 +702,6 @@ export interface components {
       truncated_key: string;
       /** Key */
       key: string;
-    };
-    /** ApiKeyInDB */
-    ApiKeyInDB: {
-      /** Truncated Key */
-      truncated_key: string;
-      /** Key */
-      key: string;
-      /** User Id */
-      user_id: string | null;
-      /** Assistant Id */
-      assistant_id: string | null;
     };
     /** AppInTemplatePublic */
     AppInTemplatePublic: {
@@ -941,29 +818,6 @@ export interface components {
        */
       user_id: string;
     };
-    /** AppTemplateCreate */
-    AppTemplateCreate: {
-      /** Name */
-      name: string;
-      /** Description */
-      description: string;
-      /** Category */
-      category: string;
-      /** Prompt */
-      prompt: string;
-      /** Organization */
-      organization?: string | null;
-      /**
-       * Completion Model Kwargs
-       * @default {}
-       */
-      completion_model_kwargs?: Record<string, never> | null;
-      wizard: components["schemas"]["AppTemplateWizard"];
-      /** Input Type */
-      input_type: string;
-      /** Input Description */
-      input_description: string | null;
-    };
     /** AppTemplateListPublic */
     AppTemplateListPublic: {
       /** Items */
@@ -1011,29 +865,6 @@ export interface components {
       type: "app";
       wizard: components["schemas"]["AppTemplateWizard"];
       organization: components["schemas"]["AppTemplateOrganization"];
-    };
-    /** AppTemplateUpdate */
-    AppTemplateUpdate: {
-      /** Name */
-      name: string;
-      /** Description */
-      description: string;
-      /** Category */
-      category: string;
-      /** Prompt */
-      prompt: string;
-      /** Organization */
-      organization?: string | null;
-      /**
-       * Completion Model Kwargs
-       * @default {}
-       */
-      completion_model_kwargs?: Record<string, never> | null;
-      wizard: components["schemas"]["AppTemplateWizard"];
-      /** Input Type */
-      input_type: string;
-      /** Input Description */
-      input_description: string | null;
     };
     /** AppTemplateWizard */
     AppTemplateWizard: {
@@ -1244,25 +1075,6 @@ export interface components {
        */
       published?: boolean;
     };
-    /** AssistantTemplateCreate */
-    AssistantTemplateCreate: {
-      /** Name */
-      name: string;
-      /** Description */
-      description: string;
-      /** Category */
-      category: string;
-      /** Prompt */
-      prompt: string;
-      /** Organization */
-      organization?: string | null;
-      /**
-       * Completion Model Kwargs
-       * @default {}
-       */
-      completion_model_kwargs?: Record<string, never> | null;
-      wizard: components["schemas"]["AssistantTemplateWizard"];
-    };
     /** AssistantTemplateListPublic */
     AssistantTemplateListPublic: {
       /** Items */
@@ -1310,25 +1122,6 @@ export interface components {
       type: "assistant";
       wizard: components["schemas"]["AssistantTemplateWizard"];
       organization: components["schemas"]["AssistantTemplateOrganization"];
-    };
-    /** AssistantTemplateUpdate */
-    AssistantTemplateUpdate: {
-      /** Name */
-      name: string;
-      /** Description */
-      description: string;
-      /** Category */
-      category: string;
-      /** Prompt */
-      prompt: string;
-      /** Organization */
-      organization?: string | null;
-      /**
-       * Completion Model Kwargs
-       * @default {}
-       */
-      completion_model_kwargs?: Record<string, never> | null;
-      wizard: components["schemas"]["AssistantTemplateWizard"];
     };
     /** AssistantTemplateWizard */
     AssistantTemplateWizard: {
@@ -1421,6 +1214,8 @@ export interface components {
        * @default false
        */
       is_org_default?: boolean;
+      /** Security Level Id */
+      security_level_id?: string | null;
     };
     /**
      * CompletionModelFamily
@@ -1472,6 +1267,8 @@ export interface components {
        * @default false
        */
       is_org_default?: boolean;
+      /** Security Level Id */
+      security_level_id?: string | null;
       /**
        * Can Access
        * @default false
@@ -1482,6 +1279,7 @@ export interface components {
        * @default true
        */
       is_locked?: boolean;
+      security_level?: components["schemas"]["SecurityLevelPublic"] | null;
     };
     /** CompletionModelPublicAppTemplate */
     CompletionModelPublicAppTemplate: {
@@ -1541,6 +1339,8 @@ export interface components {
       is_org_enabled?: boolean | null;
       /** Is Org Default */
       is_org_default?: boolean | null;
+      /** Security Level Id */
+      security_level_id?: string | null;
     };
     /** Counts */
     Counts: {
@@ -1608,32 +1408,6 @@ export interface components {
      * @enum {string}
      */
     CrawlType: "crawl" | "sitemap";
-    /** CreateAndImportSpaceRequest */
-    CreateAndImportSpaceRequest: {
-      /** Name */
-      name: string;
-      embedding_model: components["schemas"]["ModelId"];
-      /**
-       * Assistants
-       * @default []
-       */
-      assistants?: components["schemas"]["ModelId"][];
-      /**
-       * Groups
-       * @default []
-       */
-      groups?: components["schemas"]["ModelId"][];
-      /**
-       * Websites
-       * @default []
-       */
-      websites?: components["schemas"]["ModelId"][];
-      /**
-       * Members
-       * @default []
-       */
-      members?: components["schemas"]["AddSpaceMemberRequest"][];
-    };
     /** CreateGroupRequest */
     CreateGroupRequest: {
       /** Name */
@@ -1644,18 +1418,24 @@ export interface components {
     CreateSpaceAppRequest: {
       /** Name */
       name: string;
+      /** Security Level Id */
+      security_level_id?: string | null;
       from_template?: components["schemas"]["TemplateCreate"] | null;
     };
     /** CreateSpaceAssistantRequest */
     CreateSpaceAssistantRequest: {
       /** Name */
       name: string;
+      /** Security Level Id */
+      security_level_id?: string | null;
       from_template?: components["schemas"]["TemplateCreate"] | null;
     };
     /** CreateSpaceGroupsRequest */
     CreateSpaceGroupsRequest: {
       /** Name */
       name: string;
+      /** Security Level Id */
+      security_level_id?: string | null;
       embedding_model?: components["schemas"]["ModelId"] | null;
     };
     /** CreateSpaceGroupsResponse */
@@ -1678,11 +1458,15 @@ export interface components {
     CreateSpaceRequest: {
       /** Name */
       name: string;
+      /** Security Level Id */
+      security_level_id?: string | null;
     };
     /** CreateSpaceServiceRequest */
     CreateSpaceServiceRequest: {
       /** Name */
       name: string;
+      /** Security Level Id */
+      security_level_id?: string | null;
     };
     /** CreateSpaceServiceResponse */
     CreateSpaceServiceResponse: {
@@ -1766,14 +1550,35 @@ export interface components {
        * @description List of items returned in the response
        */
       items: components["schemas"]["SessionMetadataPublic"][];
-      /** Total Count */
-      total_count: number;
       /** Limit */
       limit?: number | null;
       /** Next Cursor */
       next_cursor?: string | null;
       /** Previous Cursor */
       previous_cursor?: string | null;
+      /** Total Count */
+      total_count: number;
+      /**
+       * Count
+       * @description Number of items returned in the response
+       */
+      count: number;
+    };
+    /** CursorPaginatedResponse[UserSparse] */
+    CursorPaginatedResponse_UserSparse_: {
+      /**
+       * Items
+       * @description List of items returned in the response
+       */
+      items: components["schemas"]["UserSparse"][];
+      /** Limit */
+      limit?: number | null;
+      /** Next Cursor */
+      next_cursor?: string | null;
+      /** Previous Cursor */
+      previous_cursor?: string | null;
+      /** Total Count */
+      total_count: number;
       /**
        * Count
        * @description Number of items returned in the response
@@ -1858,41 +1663,6 @@ export interface components {
       /** Success */
       success: boolean;
     };
-    /** EmbeddingModel */
-    EmbeddingModel: {
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /**
-       * Id
-       * Format: uuid
-       */
-      id: string;
-      /** Name */
-      name: string;
-      family: components["schemas"]["EmbeddingModelFamily"];
-      /** Is Deprecated */
-      is_deprecated: boolean;
-      /** Open Source */
-      open_source: boolean;
-      /** Dimensions */
-      dimensions?: number | null;
-      /** Max Input */
-      max_input?: number | null;
-      /** Hf Link */
-      hf_link?: string | null;
-      stability: components["schemas"]["ModelStability"];
-      hosting: components["schemas"]["ModelHostingLocation"];
-      /** Description */
-      description?: string | null;
-      org?: components["schemas"]["Orgs"] | null;
-      /**
-       * Is Org Enabled
-       * @default false
-       */
-      is_org_enabled?: boolean;
-    };
     /**
      * EmbeddingModelFamily
      * @enum {string}
@@ -1932,6 +1702,8 @@ export interface components {
        * @default false
        */
       is_org_enabled?: boolean;
+      /** Security Level Id */
+      security_level_id?: string | null;
       /**
        * Can Access
        * @default false
@@ -1942,6 +1714,7 @@ export interface components {
        * @default true
        */
       is_locked?: boolean;
+      security_level?: components["schemas"]["SecurityLevelPublic"] | null;
     };
     /** EmbeddingModelPublicBase */
     EmbeddingModelPublicBase: {
@@ -1972,6 +1745,14 @@ export interface components {
       /** Description */
       description?: string | null;
       org?: components["schemas"]["Orgs"] | null;
+    };
+    /** EmbeddingModelSecurityLevelUpdate */
+    EmbeddingModelSecurityLevelUpdate: {
+      /**
+       * Security Level Id
+       * Format: uuid
+       */
+      security_level_id: string;
     };
     /** EmbeddingModelSparse */
     EmbeddingModelSparse: {
@@ -2010,6 +1791,8 @@ export interface components {
        * @default false
        */
       is_org_enabled?: boolean | null;
+      /** Security Level Id */
+      security_level_id?: string | null;
     };
     /**
      * ErrorCodes
@@ -2264,6 +2047,25 @@ export interface components {
       | "audio-upload"
       | "audio-recorder"
       | "image-upload";
+    /** Integration */
+    Integration: {
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /** Name */
+      name: string;
+      /** Description */
+      description: string;
+    };
+    /** IntegrationList */
+    IntegrationList: {
+      /** Items */
+      items: components["schemas"]["Integration"][];
+      /** Count */
+      count: number;
+    };
     /** JobPublic */
     JobPublic: {
       /** Created At */
@@ -2389,31 +2191,6 @@ export interface components {
      * @enum {string}
      */
     ModelStability: "stable" | "experimental";
-    /** ModuleBase */
-    ModuleBase: {
-      /** Name */
-      name: components["schemas"]["Modules"] | string;
-    };
-    /** ModuleInDB */
-    ModuleInDB: {
-      /** Name */
-      name: components["schemas"]["Modules"] | string;
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /**
-       * Id
-       * Format: uuid
-       */
-      id: string;
-    };
-    /**
-     * Modules
-     * @description Any change to these enums will result in database changes
-     * @enum {string}
-     */
-    Modules: "eu_hosting" | "intric-applications";
     /** OpenIdConnectLogin */
     OpenIdConnectLogin: {
       /** Code */
@@ -2553,19 +2330,6 @@ export interface components {
        */
       count: number;
     };
-    /** PaginatedResponse[AllowedOriginInDB] */
-    PaginatedResponse_AllowedOriginInDB_: {
-      /**
-       * Items
-       * @description List of items returned in the response
-       */
-      items: components["schemas"]["AllowedOriginInDB"][];
-      /**
-       * Count
-       * @description Number of items returned in the response
-       */
-      count: number;
-    };
     /** PaginatedResponse[AllowedOriginPublic] */
     PaginatedResponse_AllowedOriginPublic_: {
       /**
@@ -2638,19 +2402,6 @@ export interface components {
        * @description List of items returned in the response
        */
       items: components["schemas"]["EmbeddingModelPublic"][];
-      /**
-       * Count
-       * @description Number of items returned in the response
-       */
-      count: number;
-    };
-    /** PaginatedResponse[EmbeddingModel] */
-    PaginatedResponse_EmbeddingModel_: {
-      /**
-       * Items
-       * @description List of items returned in the response
-       */
-      items: components["schemas"]["EmbeddingModel"][];
       /**
        * Count
        * @description Number of items returned in the response
@@ -2735,32 +2486,6 @@ export interface components {
        */
       count: number;
     };
-    /** PaginatedResponse[ModuleInDB] */
-    PaginatedResponse_ModuleInDB_: {
-      /**
-       * Items
-       * @description List of items returned in the response
-       */
-      items: components["schemas"]["ModuleInDB"][];
-      /**
-       * Count
-       * @description Number of items returned in the response
-       */
-      count: number;
-    };
-    /** PaginatedResponse[PredefinedRolePublic] */
-    PaginatedResponse_PredefinedRolePublic_: {
-      /**
-       * Items
-       * @description List of items returned in the response
-       */
-      items: components["schemas"]["PredefinedRolePublic"][];
-      /**
-       * Count
-       * @description Number of items returned in the response
-       */
-      count: number;
-    };
     /** PaginatedResponse[PromptSparse] */
     PaginatedResponse_PromptSparse_: {
       /**
@@ -2768,19 +2493,6 @@ export interface components {
        * @description List of items returned in the response
        */
       items: components["schemas"]["PromptSparse"][];
-      /**
-       * Count
-       * @description Number of items returned in the response
-       */
-      count: number;
-    };
-    /** PaginatedResponse[RolePublic] */
-    PaginatedResponse_RolePublic_: {
-      /**
-       * Items
-       * @description List of items returned in the response
-       */
-      items: components["schemas"]["RolePublic"][];
       /**
        * Count
        * @description Number of items returned in the response
@@ -2852,19 +2564,6 @@ export interface components {
        */
       count: number;
     };
-    /** PaginatedResponse[TenantInDB] */
-    PaginatedResponse_TenantInDB_: {
-      /**
-       * Items
-       * @description List of items returned in the response
-       */
-      items: components["schemas"]["TenantInDB"][];
-      /**
-       * Count
-       * @description Number of items returned in the response
-       */
-      count: number;
-    };
     /** PaginatedResponse[UserAdminView] */
     PaginatedResponse_UserAdminView_: {
       /**
@@ -2891,32 +2590,6 @@ export interface components {
        */
       count: number;
     };
-    /** PaginatedResponse[UserInDB] */
-    PaginatedResponse_UserInDB_: {
-      /**
-       * Items
-       * @description List of items returned in the response
-       */
-      items: components["schemas"]["UserInDB"][];
-      /**
-       * Count
-       * @description Number of items returned in the response
-       */
-      count: number;
-    };
-    /** PaginatedResponse[UserSparse] */
-    PaginatedResponse_UserSparse_: {
-      /**
-       * Items
-       * @description List of items returned in the response
-       */
-      items: components["schemas"]["UserSparse"][];
-      /**
-       * Count
-       * @description Number of items returned in the response
-       */
-      count: number;
-    };
     /** PaginatedResponse[WebsitePublic] */
     PaginatedResponse_WebsitePublic_: {
       /**
@@ -2924,19 +2597,6 @@ export interface components {
        * @description List of items returned in the response
        */
       items: components["schemas"]["WebsitePublic"][];
-      /**
-       * Count
-       * @description Number of items returned in the response
-       */
-      count: number;
-    };
-    /** PaginatedResponse[WidgetPublic] */
-    PaginatedResponse_WidgetPublic_: {
-      /**
-       * Items
-       * @description List of items returned in the response
-       */
-      items: components["schemas"]["WidgetPublic"][];
       /**
        * Count
        * @description Number of items returned in the response
@@ -2999,6 +2659,24 @@ export interface components {
       predefined_role?: components["schemas"]["ModelId"] | null;
       state?: components["schemas"]["UserState"] | null;
     };
+    /** PartialSecurityLevelUpdatePublic */
+    PartialSecurityLevelUpdatePublic: {
+      /**
+       * Name
+       * @description Name of the security level
+       */
+      name?: string | null;
+      /**
+       * Description
+       * @description Description of the security level
+       */
+      description?: string | null;
+      /**
+       * Value
+       * @description Numeric value determining the security level hierarchy
+       */
+      value?: number | null;
+    };
     /** PartialServiceUpdatePublic */
     PartialServiceUpdatePublic: {
       /** Output Format */
@@ -3020,6 +2698,8 @@ export interface components {
       name?: string | null;
       /** Description */
       description?: string | null;
+      /** Security Level Id */
+      security_level_id?: string | null;
       /** Embedding Models */
       embedding_models?: components["schemas"]["ModelId"][] | null;
       /** Completion Models */
@@ -3039,19 +2719,6 @@ export interface components {
       update_interval?: components["schemas"]["UpdateInterval"] | null;
       embedding_model?: components["schemas"]["ModelId"] | null;
     };
-    /** PartialWidgetUpdatePublic */
-    PartialWidgetUpdatePublic: {
-      /** Name */
-      name?: string | null;
-      /** Title */
-      title?: string | null;
-      /** Bot Introduction */
-      bot_introduction?: string | null;
-      /** Color */
-      color?: string | null;
-      size?: components["schemas"]["Size"] | null;
-      assistant?: components["schemas"]["ModelId"] | null;
-    };
     /**
      * Permission
      * @enum {string}
@@ -3066,28 +2733,6 @@ export interface components {
       | "editor"
       | "admin"
       | "websites";
-    /** PermissionPublic */
-    PermissionPublic: {
-      name: components["schemas"]["Permission"];
-      /** Description */
-      description: string;
-    };
-    /** PredefinedRoleInDB */
-    PredefinedRoleInDB: {
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /** Name */
-      name: string;
-      /** Permissions */
-      permissions: components["schemas"]["Permission"][];
-      /**
-       * Id
-       * Format: uuid
-       */
-      id: string;
-    };
     /** PredefinedRolePublic */
     PredefinedRolePublic: {
       /** Created At */
@@ -3172,11 +2817,6 @@ export interface components {
       is_selected: boolean;
       user: components["schemas"]["UserSparse"];
     };
-    /** PromptUpdateRequest */
-    PromptUpdateRequest: {
-      /** Description */
-      description?: string | null;
-    };
     /** PropUserInvite */
     PropUserInvite: {
       predefined_role?: components["schemas"]["ModelId"] | null;
@@ -3215,34 +2855,6 @@ export interface components {
      * @enum {string}
      */
     ResourcePermission: "read" | "create" | "edit" | "delete" | "add" | "remove" | "publish";
-    /** RoleCreateRequest */
-    RoleCreateRequest: {
-      /** Name */
-      name: string;
-      /** Permissions */
-      permissions: components["schemas"]["Permission"][];
-    };
-    /** RoleInDB */
-    RoleInDB: {
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /**
-       * Id
-       * Format: uuid
-       */
-      id: string;
-      /** Name */
-      name: string;
-      /** Permissions */
-      permissions: components["schemas"]["Permission"][];
-      /**
-       * Tenant Id
-       * Format: uuid
-       */
-      tenant_id: string;
-    };
     /** RolePublic */
     RolePublic: {
       /** Created At */
@@ -3258,18 +2870,6 @@ export interface components {
       name: string;
       /** Permissions */
       permissions: components["schemas"]["Permission"][];
-    };
-    /** RoleUpdateRequest */
-    RoleUpdateRequest: {
-      /** Name */
-      name?: string | null;
-      /** Permissions */
-      permissions?: components["schemas"]["Permission"][] | null;
-    };
-    /** RolesPaginatedResponse */
-    RolesPaginatedResponse: {
-      roles: components["schemas"]["PaginatedResponse_RolePublic_"];
-      predefined_roles: components["schemas"]["PaginatedResponse_PredefinedRolePublic_"];
     };
     /** RunAppRequest */
     RunAppRequest: {
@@ -3290,6 +2890,69 @@ export interface components {
        * @default []
        */
       files?: components["schemas"]["ModelId"][];
+    };
+    /**
+     * SecurityLevelCreatePublic
+     * @description Request model for creating a new security level.
+     */
+    SecurityLevelCreatePublic: {
+      /**
+       * Name
+       * @description Name of the security level
+       */
+      name: string;
+      /**
+       * Description
+       * @description Description of the security level
+       */
+      description?: string | null;
+      /**
+       * Value
+       * @description Numeric value determining the security level hierarchy
+       */
+      value: number;
+    };
+    /**
+     * SecurityLevelPublic
+     * @description Complete security level information including relationships.
+     */
+    SecurityLevelPublic: {
+      /** Created At */
+      created_at?: string | null;
+      /** Updated At */
+      updated_at?: string | null;
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /** Name */
+      name: string;
+      /** Description */
+      description: string | null;
+      /** Value */
+      value: number;
+    };
+    /**
+     * SecurityLevelSparse
+     * @description Basic security level information.
+     */
+    SecurityLevelSparse: {
+      /** Created At */
+      created_at?: string | null;
+      /** Updated At */
+      updated_at?: string | null;
+      /**
+       * Id
+       * Format: uuid
+       */
+      id: string;
+      /** Name */
+      name: string;
+      /** Description */
+      description: string | null;
+      /** Value */
+      value: number;
     };
     /** SemanticSearchRequest */
     SemanticSearchRequest: {
@@ -3511,11 +3174,6 @@ export interface components {
        */
       chatbot_widget?: Record<string, never>;
     };
-    /**
-     * Size
-     * @enum {string}
-     */
-    Size: "small" | "medium" | "large";
     /** SpaceDashboard */
     SpaceDashboard: {
       /**
@@ -3538,6 +3196,7 @@ export interface components {
       description: string | null;
       /** Personal */
       personal: boolean;
+      security_level: components["schemas"]["SecurityLevelSparse"] | null;
       applications: components["schemas"]["Applications"];
     };
     /** SpaceMember */
@@ -3582,6 +3241,7 @@ export interface components {
       description: string | null;
       /** Personal */
       personal: boolean;
+      security_level: components["schemas"]["SecurityLevelSparse"] | null;
       applications: components["schemas"]["Applications"];
       /** Embedding Models */
       embedding_models: components["schemas"]["EmbeddingModelSparse"][];
@@ -3626,6 +3286,27 @@ export interface components {
       description: string | null;
       /** Personal */
       personal: boolean;
+      security_level: components["schemas"]["SecurityLevelSparse"] | null;
+    };
+    /**
+     * SpaceUpdateDryRunRequest
+     * @description Request to analyze the impact of updating a space's properties.
+     */
+    SpaceUpdateDryRunRequest: {
+      /** Security Level Id */
+      security_level_id: string | null;
+    };
+    /**
+     * SpaceUpdateDryRunResponse
+     * @description Response containing the impact analysis of updating a space's properties.
+     */
+    SpaceUpdateDryRunResponse: {
+      /** Unavailable Completion Models */
+      unavailable_completion_models: components["schemas"]["CompletionModelSparse"][];
+      /** Unavailable Embedding Models */
+      unavailable_embedding_models: components["schemas"]["EmbeddingModelSparse"][];
+      current_security_level: components["schemas"]["SecurityLevelSparse"] | null;
+      new_security_level: components["schemas"]["SecurityLevelSparse"] | null;
     };
     /**
      * Status
@@ -3739,61 +3420,26 @@ export interface components {
       /** Description */
       description?: string | null;
     };
-    /** TenantBase */
-    TenantBase: {
-      /** Name */
-      name: string;
-      /** Display Name */
-      display_name?: string | null;
-      /**
-       * Quota Limit
-       * @description Size in bytes. Default is 10 GB
-       * @default 10737418240
-       */
-      quota_limit?: number;
-      /** Domain */
-      domain?: string | null;
-      /** Zitadel Org Id */
-      zitadel_org_id?: string | null;
-      /**
-       * Provisioning
-       * @default false
-       */
-      provisioning?: boolean;
-    };
-    /** TenantInDB */
-    TenantInDB: {
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
+    /** TenantIntegration */
+    TenantIntegration: {
       /**
        * Id
        * Format: uuid
        */
       id: string;
-      /** Privacy Policy */
-      privacy_policy?: string | null;
       /** Name */
       name: string;
-      /** Display Name */
-      display_name?: string | null;
-      /** Quota Limit */
-      quota_limit: number;
-      /** Domain */
-      domain?: string | null;
-      /** Zitadel Org Id */
-      zitadel_org_id?: string | null;
-      /**
-       * Provisioning
-       * @default false
-       */
-      provisioning?: boolean;
-      /**
-       * Modules
-       * @default []
-       */
-      modules?: components["schemas"]["ModuleInDB"][];
+      /** Description */
+      description: string;
+      /** Enabled */
+      enabled: boolean;
+    };
+    /** TenantIntegrationList */
+    TenantIntegrationList: {
+      /** Items */
+      items: components["schemas"]["TenantIntegration"][];
+      /** Count */
+      count: number;
     };
     /** TenantPublic */
     TenantPublic: {
@@ -3818,19 +3464,6 @@ export interface components {
       provisioning?: boolean;
       /** Privacy Policy */
       privacy_policy?: string | null;
-    };
-    /** TenantUpdatePublic */
-    TenantUpdatePublic: {
-      /** Display Name */
-      display_name?: string | null;
-      /** Quota Limit */
-      quota_limit?: number | null;
-      /** Domain */
-      domain?: string | null;
-      /** Zitadel Org Id */
-      zitadel_org_id?: string | null;
-      /** Provisioning */
-      provisioning?: boolean | null;
     };
     /** ToolAssistant */
     ToolAssistant: {
@@ -3909,38 +3542,6 @@ export interface components {
        */
       predefined_roles?: components["schemas"]["ModelId"][];
     };
-    /** UserAddSuperAdmin */
-    UserAddSuperAdmin: {
-      /**
-       * Email
-       * Format: email
-       */
-      email: string;
-      /** Username */
-      username?: string | null;
-      /** Password */
-      password?: string | null;
-      /**
-       * Quota Limit
-       * @description Size in bytes
-       */
-      quota_limit?: number | null;
-      /**
-       * Roles
-       * @default []
-       */
-      roles?: components["schemas"]["ModelId"][];
-      /**
-       * Predefined Roles
-       * @default []
-       */
-      predefined_roles?: components["schemas"]["ModelId"][];
-      /**
-       * Tenant Id
-       * Format: uuid
-       */
-      tenant_id: string;
-    };
     /** UserAdminView */
     UserAdminView: {
       /**
@@ -3979,81 +3580,6 @@ export interface components {
       predefined_roles: components["schemas"]["PredefinedRolePublic"][];
       /** User Groups */
       user_groups: components["schemas"]["UserGroupRead"][];
-    };
-    /** UserCreated */
-    UserCreated: {
-      /**
-       * Email
-       * Format: email
-       */
-      email: string;
-      /** Username */
-      username?: string | null;
-      /**
-       * Id
-       * Format: uuid
-       */
-      id: string;
-      /** Password */
-      password?: string | null;
-      /** Salt */
-      salt?: string | null;
-      /**
-       * Used Tokens
-       * @default 0
-       */
-      used_tokens?: number;
-      /**
-       * Email Verified
-       * @default false
-       */
-      email_verified?: boolean;
-      /**
-       * Is Active
-       * @default true
-       */
-      is_active?: boolean;
-      state: components["schemas"]["UserState"];
-      /**
-       * Tenant Id
-       * Format: uuid
-       */
-      tenant_id: string;
-      /** Quota Limit */
-      quota_limit?: number | null;
-      /**
-       * Roles
-       * @default []
-       */
-      roles?: components["schemas"]["RoleInDB"][];
-      /**
-       * Predefined Roles
-       * @default []
-       */
-      predefined_roles?: components["schemas"]["PredefinedRoleInDB"][];
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /**
-       * User Groups
-       * @default []
-       */
-      user_groups?: components["schemas"]["UserGroupInDBRead"][];
-      tenant: components["schemas"]["TenantInDB"];
-      api_key: components["schemas"]["ApiKey"] | null;
-      /**
-       * Quota Used
-       * @default 0
-       */
-      quota_used?: number;
-      access_token: components["schemas"]["AccessToken"] | null;
-      /** Modules */
-      modules: readonly string[];
-      /** User Groups Ids */
-      user_groups_ids: readonly number[];
-      /** Permissions */
-      permissions: readonly components["schemas"]["Permission"][];
     };
     /** UserCreatedAdminView */
     UserCreatedAdminView: {
@@ -4100,20 +3626,6 @@ export interface components {
       /** Name */
       name: string;
     };
-    /** UserGroupInDBRead */
-    UserGroupInDBRead: {
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /**
-       * Id
-       * Format: uuid
-       */
-      id: string;
-      /** Name */
-      name: string;
-    };
     /** UserGroupPublic */
     UserGroupPublic: {
       /** Created At */
@@ -4157,79 +3669,26 @@ export interface components {
        */
       users?: components["schemas"]["ModelId"][];
     };
-    /** UserInDB */
-    UserInDB: {
-      /**
-       * Email
-       * Format: email
-       */
-      email: string;
-      /** Username */
-      username?: string | null;
+    /** UserIntegration */
+    UserIntegration: {
       /**
        * Id
        * Format: uuid
        */
       id: string;
-      /** Password */
-      password?: string | null;
-      /** Salt */
-      salt?: string | null;
-      /**
-       * Used Tokens
-       * @default 0
-       */
-      used_tokens?: number;
-      /**
-       * Email Verified
-       * @default false
-       */
-      email_verified?: boolean;
-      /**
-       * Is Active
-       * @default true
-       */
-      is_active?: boolean;
-      state: components["schemas"]["UserState"];
-      /**
-       * Tenant Id
-       * Format: uuid
-       */
-      tenant_id: string;
-      /** Quota Limit */
-      quota_limit?: number | null;
-      /**
-       * Roles
-       * @default []
-       */
-      roles?: components["schemas"]["RoleInDB"][];
-      /**
-       * Predefined Roles
-       * @default []
-       */
-      predefined_roles?: components["schemas"]["PredefinedRoleInDB"][];
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /**
-       * User Groups
-       * @default []
-       */
-      user_groups?: components["schemas"]["UserGroupInDBRead"][];
-      tenant: components["schemas"]["TenantInDB"];
-      api_key?: components["schemas"]["ApiKeyInDB"] | null;
-      /**
-       * Quota Used
-       * @default 0
-       */
-      quota_used?: number;
-      /** Modules */
-      modules: readonly string[];
-      /** User Groups Ids */
-      user_groups_ids: readonly number[];
-      /** Permissions */
-      permissions: readonly components["schemas"]["Permission"][];
+      /** Name */
+      name: string;
+      /** Description */
+      description: string;
+      /** Connected */
+      connected: boolean;
+    };
+    /** UserIntegrationList */
+    UserIntegrationList: {
+      /** Items */
+      items: components["schemas"]["UserIntegration"][];
+      /** Count */
+      count: number;
     };
     /** UserProvision */
     UserProvision: {
@@ -4442,49 +3901,6 @@ export interface components {
       user_id: string;
       embedding_model: components["schemas"]["IdAndName"];
       metadata: components["schemas"]["WebsiteMetadata"];
-    };
-    /** WidgetCreatePublic */
-    WidgetCreatePublic: {
-      /** Name */
-      name: string;
-      /** Title */
-      title: string;
-      /** Bot Introduction */
-      bot_introduction: string;
-      /**
-       * Color
-       * Format: color
-       */
-      color: string;
-      size: components["schemas"]["Size"];
-      assistant: components["schemas"]["ModelId"];
-    };
-    /** WidgetPublic */
-    WidgetPublic: {
-      /** Created At */
-      created_at?: string | null;
-      /** Updated At */
-      updated_at?: string | null;
-      /**
-       * Id
-       * Format: uuid
-       */
-      id: string;
-      /** Name */
-      name: string;
-      /** Title */
-      title: string;
-      /** Bot Introduction */
-      bot_introduction: string;
-      /**
-       * Color
-       * Format: color
-       */
-      color: string;
-      size: components["schemas"]["Size"];
-      /** Privacy Policy */
-      privacy_policy?: string | null;
-      assistant: components["schemas"]["ModelId"];
     };
     /**
      * WizardType
@@ -4804,43 +4220,6 @@ export interface operations {
       };
     };
   };
-  /** Publish App */
-  publish_app_api_v1_apps__id__publish__post: {
-    parameters: {
-      query: {
-        published: boolean;
-      };
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["AppPublic"];
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
   /** Get App Run */
   get_app_run_api_v1_app_runs__id___get: {
     parameters: {
@@ -4965,11 +4344,29 @@ export interface operations {
   };
   /** Get Tenant Users */
   get_tenant_users_api_v1_users__get: {
+    parameters: {
+      query?: {
+        /** @description Email of user */
+        email?: string | null;
+        /** @description Users per page */
+        limit?: number;
+        /** @description Current cursor */
+        cursor?: string | null;
+        /** @description Show previous page */
+        previous?: boolean | null;
+      };
+    };
     responses: {
       /** @description Successful Response */
       200: {
         content: {
-          "application/json": components["schemas"]["PaginatedResponse_UserSparse_"];
+          "application/json": components["schemas"]["CursorPaginatedResponse_UserSparse_"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };
@@ -5890,6 +5287,8 @@ export interface operations {
                  * @default false
                  */
                 is_org_default?: boolean;
+                /** Security Level Id */
+                security_level_id?: string | null;
                 /**
                  * Can Access
                  * @default false
@@ -5900,6 +5299,7 @@ export interface operations {
                  * @default true
                  */
                 is_locked?: boolean;
+                security_level?: components["schemas"]["SecurityLevelPublic"] | null;
               };
               /** FilePublic */
               FilePublic: {
@@ -5975,6 +5375,27 @@ export interface operations {
                * @enum {string}
                */
               Orgs: "OpenAI" | "Meta" | "Microsoft" | "Anthropic";
+              /**
+               * SecurityLevelPublic
+               * @description Complete security level information including relationships.
+               */
+              SecurityLevelPublic: {
+                /** Created At */
+                created_at?: string | null;
+                /** Updated At */
+                updated_at?: string | null;
+                /**
+                 * Id
+                 * Format: uuid
+                 */
+                id: string;
+                /** Name */
+                name: string;
+                /** Description */
+                description: string | null;
+                /** Value */
+                value: number;
+              };
               /** UseTools */
               UseTools: {
                 /** Assistants */
@@ -6130,6 +5551,8 @@ export interface operations {
                  * @default false
                  */
                 is_org_default?: boolean;
+                /** Security Level Id */
+                security_level_id?: string | null;
                 /**
                  * Can Access
                  * @default false
@@ -6140,6 +5563,7 @@ export interface operations {
                  * @default true
                  */
                 is_locked?: boolean;
+                security_level?: components["schemas"]["SecurityLevelPublic"] | null;
               };
               /** FilePublic */
               FilePublic: {
@@ -6215,6 +5639,27 @@ export interface operations {
                * @enum {string}
                */
               Orgs: "OpenAI" | "Meta" | "Microsoft" | "Anthropic";
+              /**
+               * SecurityLevelPublic
+               * @description Complete security level information including relationships.
+               */
+              SecurityLevelPublic: {
+                /** Created At */
+                created_at?: string | null;
+                /** Updated At */
+                updated_at?: string | null;
+                /**
+                 * Id
+                 * Format: uuid
+                 */
+                id: string;
+                /** Name */
+                name: string;
+                /** Description */
+                description: string | null;
+                /** Value */
+                value: number;
+              };
               /** UseTools */
               UseTools: {
                 /** Assistants */
@@ -6363,65 +5808,6 @@ export interface operations {
       /** @description Successful Response */
       204: {
         content: never;
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Get Prompts */
-  get_prompts_api_v1_assistants__id__prompts__get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PaginatedResponse_PromptSparse_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Publish Assistant */
-  publish_assistant_api_v1_assistants__id__publish__post: {
-    parameters: {
-      query: {
-        published: boolean;
-      };
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["AssistantPublic"];
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
       };
       /** @description Validation Error */
       422: {
@@ -6950,6 +6336,242 @@ export interface operations {
       };
     };
   };
+  /**
+   * List Security Levels
+   * @description List all security levels for the current tenant ordered by value.
+   *
+   * Returns:
+   *     List of security levels ordered by value.
+   *
+   * Raises:
+   *     403: If the user doesn't have permission to list security levels.
+   */
+  list_security_levels_api_v1_security_levels_get: {
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SecurityLevelPublic"][];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+    };
+  };
+  /**
+   * Create Security Level
+   * @description Create a new security level for the current tenant.
+   *
+   * Args:
+   *     request: The security level creation request.
+   *
+   * Returns:
+   *     The created security level.
+   *
+   * Raises:
+   *     400: If the request is invalid.
+   *     409: If a security level with the same name already exists for this tenant.
+   */
+  create_security_level_api_v1_security_levels_post: {
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SecurityLevelCreatePublic"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        content: {
+          "application/json": components["schemas"]["SecurityLevelPublic"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Get Security Level
+   * @description Get a security level by ID.
+   *
+   * Args:
+   *     id: The ID of the security level.
+   *
+   * Returns:
+   *     The security level.
+   *
+   * Raises:
+   *     403: If the user doesn't have permission to view the security level.
+   *     404: If the security level doesn't exist or belongs to a different tenant.
+   */
+  get_security_level_api_v1_security_levels__id__get: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SecurityLevelPublic"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Delete Security Level
+   * @description Delete a security level.
+   *
+   * Args:
+   *     id: The ID of the security level to delete.
+   *
+   * Raises:
+   *     403: If the user doesn't have permission to delete the security level.
+   *     404: If the security level doesn't exist or belongs to a different tenant.
+   *     409: If the security level is in use by any spaces or models.
+   */
+  delete_security_level_api_v1_security_levels__id__delete: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      204: {
+        content: never;
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /**
+   * Update Security Level
+   * @description Update a security level.
+   *
+   * Args:
+   *     id: The ID of the security level to update.
+   *     request: The update request.
+   *
+   * Returns:
+   *     The updated security level.
+   *
+   * Raises:
+   *     400: If the request is invalid.
+   *     403: If the user doesn't have permission to update the security level.
+   *     404: If the security level doesn't exist or belongs to a different tenant.
+   *     409: If updating the name would create a duplicate within the tenant.
+   */
+  update_security_level_api_v1_security_levels__id__patch: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["PartialSecurityLevelUpdatePublic"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SecurityLevelPublic"];
+        };
+      };
+      /** @description Bad Request */
+      400: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Forbidden */
+      403: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Conflict */
+      409: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
   /** Get Jobs */
   get_jobs_api_v1_jobs__get: {
     parameters: {
@@ -7263,6 +6885,61 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Set Embedding Model Security Level */
+  set_embedding_model_security_level_api_v1_embedding_models__id__security_level_put: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["EmbeddingModelSecurityLevelUpdate"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["EmbeddingModelPublic"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
+  /** Unset Embedding Model Security Level */
+  unset_embedding_model_security_level_api_v1_embedding_models__id__security_level_delete: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["EmbeddingModelPublic"];
         };
       };
       /** @description Validation Error */
@@ -7925,6 +7602,44 @@ export interface operations {
       };
     };
   };
+  /**
+   * Update Space Dryrun
+   * @description Analyze the impact of updating a space's properties without actually applying the changes.
+   * Currently supports:
+   * - Security level changes: Shows which models would be affected
+   */
+  update_space_dryrun_api_v1_spaces__id__update_dryrun__post: {
+    parameters: {
+      path: {
+        id: string;
+      };
+    };
+    requestBody: {
+      content: {
+        "application/json": components["schemas"]["SpaceUpdateDryRunRequest"];
+      };
+    };
+    responses: {
+      /** @description Successful Response */
+      200: {
+        content: {
+          "application/json": components["schemas"]["SpaceUpdateDryRunResponse"];
+        };
+      };
+      /** @description Not Found */
+      404: {
+        content: {
+          "application/json": components["schemas"]["GeneralError"];
+        };
+      };
+      /** @description Validation Error */
+      422: {
+        content: {
+          "application/json": components["schemas"]["HTTPValidationError"];
+        };
+      };
+    };
+  };
   /** Get Dashboard */
   get_dashboard_api_v1_dashboard__get: {
     responses: {
@@ -8188,123 +7903,6 @@ export interface operations {
       };
     };
   };
-  /** Get Prompt */
-  get_prompt_api_v1_prompts__id___get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PromptPublic"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Delete Prompt */
-  delete_prompt_api_v1_prompts__id___delete: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      204: {
-        content: never;
-      };
-      /** @description Forbidden */
-      403: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Update Prompt Description */
-  update_prompt_description_api_v1_prompts__id___patch: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PromptUpdateRequest"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PromptPublic"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Forbidden */
-      403: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
   /**
    * Get Templates
    * @description Get all app templates
@@ -8331,171 +7929,6 @@ export interface operations {
       };
     };
   };
-  /** Create App Template */
-  create_app_template_api_v1_templates_apps__post: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AppTemplateCreate"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        content: {
-          "application/json": unknown;
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /**
-   * Get Templates Admin
-   * @description Get all app templates from Admin
-   */
-  get_templates_admin_api_v1_templates_apps_admin__get: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["AppTemplateListPublic"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-    };
-  };
-  /** Get App Template */
-  get_app_template_api_v1_templates_apps__id__get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["AppTemplatePublic"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Update App Template */
-  update_app_template_api_v1_templates_apps__id___put: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AppTemplateUpdate"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["AppTemplatePublic"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Delete App Template */
-  delete_app_template_api_v1_templates_apps__id___delete: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      204: {
-        content: never;
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
   /**
    * Get Templates
    * @description Get all assistant templates
@@ -8518,171 +7951,6 @@ export interface operations {
       404: {
         content: {
           "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-    };
-  };
-  /** Create Assistant Template */
-  create_assistant_template_api_v1_templates_assistants__post: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AssistantTemplateCreate"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      201: {
-        content: {
-          "application/json": unknown;
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /**
-   * Get Templates Admin
-   * @description Get all assistant templates from Admin
-   */
-  get_templates_admin_api_v1_templates_assistants_admin__get: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["AssistantTemplateListPublic"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-    };
-  };
-  /** Get Assistant Template */
-  get_assistant_template_api_v1_templates_assistants__id___get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["AssistantTemplatePublic"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Update Assistant Template */
-  update_assistant_template_api_v1_templates_assistants__id___put: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AssistantTemplateUpdate"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": unknown;
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Delete Assistant Template */
-  delete_assistant_template_api_v1_templates_assistants__id___delete: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      204: {
-        content: never;
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
         };
       };
     };
@@ -8723,1229 +7991,35 @@ export interface operations {
       };
     };
   };
-  /** Get Tenant Widgets */
-  get_tenant_widgets_api_v1_widgets__get: {
-    parameters: {
-      query?: {
-        assistant_id?: string;
-      };
-    };
+  /** Get Integrations */
+  get_integrations_api_v1_integrations__get: {
     responses: {
       /** @description Successful Response */
       200: {
         content: {
-          "application/json": components["schemas"]["PaginatedResponse_WidgetPublic_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
+          "application/json": components["schemas"]["IntegrationList"];
         };
       };
     };
   };
-  /** Add Widget */
-  add_widget_api_v1_widgets__post: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["WidgetCreatePublic"];
-      };
-    };
+  /** Get Tenant Integrations */
+  get_tenant_integrations_api_v1_integrations_tenant__get: {
     responses: {
       /** @description Successful Response */
       200: {
         content: {
-          "application/json": components["schemas"]["WidgetPublic"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
+          "application/json": components["schemas"]["TenantIntegrationList"];
         };
       };
     };
   };
-  /** Get Widget */
-  get_widget_api_v1_widgets__id___get: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
+  /** Get User Integrations */
+  get_user_integrations_api_v1_integrations_me__get: {
     responses: {
       /** @description Successful Response */
       200: {
         content: {
-          "application/json": components["schemas"]["WidgetPublic"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Update Widget */
-  update_widget_api_v1_widgets__id___post: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PartialWidgetUpdatePublic"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["WidgetPublic"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Delete Widget */
-  delete_widget_api_v1_widgets__id___delete: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["DeleteResponse"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Ask Assistant */
-  ask_assistant_api_v1_widgets__id__sessions__post: {
-    parameters: {
-      query?: {
-        version?: number;
-      };
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AskAssistant"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["AskResponse"];
-          "text/event-stream": {
-            /**
-             * Session Id
-             * Format: uuid
-             */
-            session_id: string;
-            /** Question */
-            question: string;
-            /** Files */
-            files: components["schemas"]["FilePublic"][];
-            /** Answer */
-            answer: string;
-            /** References */
-            references: components["schemas"]["InfoBlobAskAssistantPublic"][];
-            model?: components["schemas"]["CompletionModelPublic"] | null;
-            tools: components["schemas"]["UseTools"];
-            $defs: {
-              /**
-               * CompletionModelFamily
-               * @enum {string}
-               */
-              CompletionModelFamily: "openai" | "mistral" | "vllm" | "claude" | "azure";
-              /** CompletionModelPublic */
-              CompletionModelPublic: {
-                /** Created At */
-                created_at?: string | null;
-                /** Updated At */
-                updated_at?: string | null;
-                /**
-                 * Id
-                 * Format: uuid
-                 */
-                id: string;
-                /** Name */
-                name: string;
-                /** Nickname */
-                nickname: string;
-                family: components["schemas"]["CompletionModelFamily"];
-                /** Token Limit */
-                token_limit: number;
-                /** Is Deprecated */
-                is_deprecated: boolean;
-                /** Nr Billion Parameters */
-                nr_billion_parameters?: number | null;
-                /** Hf Link */
-                hf_link?: string | null;
-                stability: components["schemas"]["ModelStability"];
-                hosting: components["schemas"]["ModelHostingLocation"];
-                /** Open Source */
-                open_source?: boolean | null;
-                /** Description */
-                description?: string | null;
-                /** Deployment Name */
-                deployment_name?: string | null;
-                org?: components["schemas"]["Orgs"] | null;
-                /** Vision */
-                vision: boolean;
-                /**
-                 * Is Org Enabled
-                 * @default false
-                 */
-                is_org_enabled?: boolean;
-                /**
-                 * Is Org Default
-                 * @default false
-                 */
-                is_org_default?: boolean;
-                /**
-                 * Can Access
-                 * @default false
-                 */
-                can_access?: boolean;
-                /**
-                 * Is Locked
-                 * @default true
-                 */
-                is_locked?: boolean;
-              };
-              /** FilePublic */
-              FilePublic: {
-                /** Created At */
-                created_at?: string | null;
-                /** Updated At */
-                updated_at?: string | null;
-                /**
-                 * Id
-                 * Format: uuid
-                 */
-                id: string;
-                /** Name */
-                name: string;
-                /** Mimetype */
-                mimetype: string;
-                /** Size */
-                size: number;
-              };
-              /** InfoBlobAskAssistantPublic */
-              InfoBlobAskAssistantPublic: {
-                /** Created At */
-                created_at?: string | null;
-                /** Updated At */
-                updated_at?: string | null;
-                /**
-                 * Id
-                 * Format: uuid
-                 */
-                id: string;
-                metadata: components["schemas"]["InfoBlobMetadata"];
-                /** Group Id */
-                group_id?: string | null;
-                /** Website Id */
-                website_id?: string | null;
-                /** Score */
-                score: number;
-              };
-              /** InfoBlobMetadata */
-              InfoBlobMetadata: {
-                /** Url */
-                url?: string | null;
-                /** Title */
-                title?: string | null;
-                /**
-                 * Embedding Model Id
-                 * Format: uuid
-                 */
-                embedding_model_id: string;
-                /** Size */
-                size: number;
-              };
-              /**
-               * ModelHostingLocation
-               * @enum {string}
-               */
-              ModelHostingLocation: "usa" | "eu" | "swe";
-              /** ModelId */
-              ModelId: {
-                /**
-                 * Id
-                 * Format: uuid
-                 */
-                id: string;
-              };
-              /**
-               * ModelStability
-               * @enum {string}
-               */
-              ModelStability: "stable" | "experimental";
-              /**
-               * Orgs
-               * @enum {string}
-               */
-              Orgs: "OpenAI" | "Meta" | "Microsoft" | "Anthropic";
-              /** UseTools */
-              UseTools: {
-                /** Assistants */
-                assistants: components["schemas"]["ModelId"][];
-              };
-            };
-          };
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Ask Followup */
-  ask_followup_api_v1_widgets__id__sessions__session_id___post: {
-    parameters: {
-      query?: {
-        version?: number;
-      };
-      path: {
-        id: string;
-        session_id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AskAssistant"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["AskResponse"];
-          "text/event-stream": {
-            /**
-             * Session Id
-             * Format: uuid
-             */
-            session_id: string;
-            /** Question */
-            question: string;
-            /** Files */
-            files: components["schemas"]["FilePublic"][];
-            /** Answer */
-            answer: string;
-            /** References */
-            references: components["schemas"]["InfoBlobAskAssistantPublic"][];
-            model?: components["schemas"]["CompletionModelPublic"] | null;
-            tools: components["schemas"]["UseTools"];
-            $defs: {
-              /**
-               * CompletionModelFamily
-               * @enum {string}
-               */
-              CompletionModelFamily: "openai" | "mistral" | "vllm" | "claude" | "azure";
-              /** CompletionModelPublic */
-              CompletionModelPublic: {
-                /** Created At */
-                created_at?: string | null;
-                /** Updated At */
-                updated_at?: string | null;
-                /**
-                 * Id
-                 * Format: uuid
-                 */
-                id: string;
-                /** Name */
-                name: string;
-                /** Nickname */
-                nickname: string;
-                family: components["schemas"]["CompletionModelFamily"];
-                /** Token Limit */
-                token_limit: number;
-                /** Is Deprecated */
-                is_deprecated: boolean;
-                /** Nr Billion Parameters */
-                nr_billion_parameters?: number | null;
-                /** Hf Link */
-                hf_link?: string | null;
-                stability: components["schemas"]["ModelStability"];
-                hosting: components["schemas"]["ModelHostingLocation"];
-                /** Open Source */
-                open_source?: boolean | null;
-                /** Description */
-                description?: string | null;
-                /** Deployment Name */
-                deployment_name?: string | null;
-                org?: components["schemas"]["Orgs"] | null;
-                /** Vision */
-                vision: boolean;
-                /**
-                 * Is Org Enabled
-                 * @default false
-                 */
-                is_org_enabled?: boolean;
-                /**
-                 * Is Org Default
-                 * @default false
-                 */
-                is_org_default?: boolean;
-                /**
-                 * Can Access
-                 * @default false
-                 */
-                can_access?: boolean;
-                /**
-                 * Is Locked
-                 * @default true
-                 */
-                is_locked?: boolean;
-              };
-              /** FilePublic */
-              FilePublic: {
-                /** Created At */
-                created_at?: string | null;
-                /** Updated At */
-                updated_at?: string | null;
-                /**
-                 * Id
-                 * Format: uuid
-                 */
-                id: string;
-                /** Name */
-                name: string;
-                /** Mimetype */
-                mimetype: string;
-                /** Size */
-                size: number;
-              };
-              /** InfoBlobAskAssistantPublic */
-              InfoBlobAskAssistantPublic: {
-                /** Created At */
-                created_at?: string | null;
-                /** Updated At */
-                updated_at?: string | null;
-                /**
-                 * Id
-                 * Format: uuid
-                 */
-                id: string;
-                metadata: components["schemas"]["InfoBlobMetadata"];
-                /** Group Id */
-                group_id?: string | null;
-                /** Website Id */
-                website_id?: string | null;
-                /** Score */
-                score: number;
-              };
-              /** InfoBlobMetadata */
-              InfoBlobMetadata: {
-                /** Url */
-                url?: string | null;
-                /** Title */
-                title?: string | null;
-                /**
-                 * Embedding Model Id
-                 * Format: uuid
-                 */
-                embedding_model_id: string;
-                /** Size */
-                size: number;
-              };
-              /**
-               * ModelHostingLocation
-               * @enum {string}
-               */
-              ModelHostingLocation: "usa" | "eu" | "swe";
-              /** ModelId */
-              ModelId: {
-                /**
-                 * Id
-                 * Format: uuid
-                 */
-                id: string;
-              };
-              /**
-               * ModelStability
-               * @enum {string}
-               */
-              ModelStability: "stable" | "experimental";
-              /**
-               * Orgs
-               * @enum {string}
-               */
-              Orgs: "OpenAI" | "Meta" | "Microsoft" | "Anthropic";
-              /** UseTools */
-              UseTools: {
-                /** Assistants */
-                assistants: components["schemas"]["ModelId"][];
-              };
-            };
-          };
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Get Privacy Policy */
-  get_privacy_policy_api_v1_widgets_settings_privacy_policy__get: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PrivacyPolicy"];
-        };
-      };
-    };
-  };
-  /** Set Privacy Policy */
-  set_privacy_policy_api_v1_widgets_settings_privacy_policy__post: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["PrivacyPolicy"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PrivacyPolicy"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Get All Users */
-  get_all_users_api_v1_sysadmin_users__get: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PaginatedResponse_UserInDB_"];
-        };
-      };
-    };
-  };
-  /** Register New User */
-  register_new_user_api_v1_sysadmin_users__post: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UserAddSuperAdmin"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["UserCreated"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Unauthorized */
-      401: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Get User */
-  get_user_api_v1_sysadmin_users__user_id___get: {
-    parameters: {
-      path: {
-        user_id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["UserInDB"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /**
-   * Update User
-   * @description Omitted fields are not updated.
-   */
-  update_user_api_v1_sysadmin_users__user_id___post: {
-    parameters: {
-      path: {
-        user_id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["UserUpdatePublic"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["UserInDB"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Delete User */
-  delete_user_api_v1_sysadmin_users__user_id___delete: {
-    parameters: {
-      path: {
-        user_id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["DeleteResponse"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Get Tenants */
-  get_tenants_api_v1_sysadmin_tenants__get: {
-    parameters: {
-      query?: {
-        domain?: string | null;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PaginatedResponse_TenantInDB_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Create Tenant */
-  create_tenant_api_v1_sysadmin_tenants__post: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["TenantBase"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TenantInDB"];
-        };
-      };
-      /** @description Bad Request */
-      400: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Update Tenant */
-  update_tenant_api_v1_sysadmin_tenants__id___post: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["TenantUpdatePublic"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TenantInDB"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Delete Tenant By Id */
-  delete_tenant_by_id_api_v1_sysadmin_tenants__id___delete: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TenantInDB"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Get Predefined Roles */
-  get_predefined_roles_api_v1_sysadmin_predefined_roles__get: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": unknown;
-        };
-      };
-    };
-  };
-  /** Crawl All Weekly Websites */
-  crawl_all_weekly_websites_api_v1_sysadmin_crawl_all_weekly_websites__post: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": unknown;
-        };
-      };
-    };
-  };
-  /** Get Embedding Models */
-  get_embedding_models_api_v1_sysadmin_embedding_models__get: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PaginatedResponse_EmbeddingModel_"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-    };
-  };
-  /** Get Completion Models */
-  get_completion_models_api_v1_sysadmin_completion_models__get: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PaginatedResponse_CompletionModelPublic_"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-    };
-  };
-  /** Enable Completion Model */
-  enable_completion_model_api_v1_sysadmin_tenants__id__completion_models__completion_model_id___post: {
-    parameters: {
-      path: {
-        id: string;
-        completion_model_id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CompletionModelUpdateFlags"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["CompletionModelPublic"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Enable Embedding Model */
-  enable_embedding_model_api_v1_sysadmin_tenants__id__embedding_models__embedding_model_id___post: {
-    parameters: {
-      path: {
-        id: string;
-        embedding_model_id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["EmbeddingModelUpdateFlags"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["EmbeddingModelPublic"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Create Space And Import */
-  create_space_and_import_api_v1_sysadmin_spaces_import__post: {
-    parameters: {
-      query: {
-        user_id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["CreateAndImportSpaceRequest"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": unknown;
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Migrate To Spaces */
-  migrate_to_spaces_api_v1_sysadmin_migrations_migrate_to_spaces__post: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": unknown;
-        };
-      };
-    };
-  };
-  /** Get Origins */
-  get_origins_api_v1_sysadmin_allowed_origins__get: {
-    parameters: {
-      query?: {
-        tenant_id?: string | null;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PaginatedResponse_AllowedOriginInDB_"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Add Origin */
-  add_origin_api_v1_sysadmin_allowed_origins__post: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["AllowedOriginCreate"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["AllowedOriginInDB"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Delete Origin */
-  delete_origin_api_v1_sysadmin_allowed_origins__id___delete: {
-    parameters: {
-      path: {
-        id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      204: {
-        content: never;
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Get Modules */
-  get_modules_api_v1_modules__get: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PaginatedResponse_ModuleInDB_"];
-        };
-      };
-    };
-  };
-  /** Add Module */
-  add_module_api_v1_modules__post: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ModuleBase"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["ModuleInDB"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /**
-   * Add Module To Tenant
-   * @description Value is a list of module `id`'s to add to the `tenant_id`.
-   */
-  add_module_to_tenant_api_v1_modules__tenant_id___post: {
-    parameters: {
-      path: {
-        tenant_id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["ModelId"][];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["TenantInDB"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Get Permissions */
-  get_permissions_api_v1_roles_permissions__get: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["PermissionPublic"][];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-    };
-  };
-  /** Get Roles */
-  get_roles_api_v1_roles__get: {
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["RolesPaginatedResponse"];
-        };
-      };
-    };
-  };
-  /** Create Role */
-  create_role_api_v1_roles__post: {
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["RoleCreateRequest"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["RolePublic"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Get Role By Id */
-  get_role_by_id_api_v1_roles__role_id___get: {
-    parameters: {
-      path: {
-        role_id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["RolePublic"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Update Role */
-  update_role_api_v1_roles__role_id___post: {
-    parameters: {
-      path: {
-        role_id: string;
-      };
-    };
-    requestBody: {
-      content: {
-        "application/json": components["schemas"]["RoleUpdateRequest"];
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["RolePublic"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
-        };
-      };
-    };
-  };
-  /** Delete Role By Id */
-  delete_role_by_id_api_v1_roles__role_id___delete: {
-    parameters: {
-      path: {
-        role_id: string;
-      };
-    };
-    responses: {
-      /** @description Successful Response */
-      200: {
-        content: {
-          "application/json": components["schemas"]["RolePublic"];
-        };
-      };
-      /** @description Not Found */
-      404: {
-        content: {
-          "application/json": components["schemas"]["GeneralError"];
-        };
-      };
-      /** @description Validation Error */
-      422: {
-        content: {
-          "application/json": components["schemas"]["HTTPValidationError"];
+          "application/json": components["schemas"]["UserIntegrationList"];
         };
       };
     };


### PR DESCRIPTION
## Summary
This PR introduces the concept of **security levels**, enhancing the control over which AI models can be utilized within different Spaces based on their security requirements. Security levels are defined by a name, description, and a numeric value that dictates access permissions. This feature allows administrators to assign security levels to both models and Spaces, ensuring that only models meeting the required security criteria are accessible within a given Space.


## Notes
* Changing security level on a space disables models that will no longer be available. The existing validation of model availability on assistants remains the same. 
* Running pnpm install updates `frontend/pnpm-lock.yaml` by using `'` instead of `"`, also some packages are removed (widgets for example). This PR does not add/change any dependencies so the updated file is not included in this PR.
* The `frontend/packages/intric-js/src/types/schema.d.ts` does not seem to be up-to-date. We get a bigger diff  than expected that contains unrelated changes. Not sure how this is supposed to be managed, but we have manually changed the  `frontend/packages/intric-js/update.js` to use the local backend when regenerating.

## Screenshots
### List security levels
![Screenshot 2025-02-21 at 09 36 59](https://github.com/user-attachments/assets/06478bec-928a-48b4-a458-6922c76ce603)
### Create/edit security level
![Screenshot 2025-02-21 at 09 37 08](https://github.com/user-attachments/assets/a699fd24-3235-4acc-b03c-fef7a76de7f6)
### Space security level admin
![Screenshot 2025-02-21 at 09 37 31](https://github.com/user-attachments/assets/8a84476a-fb54-4767-aa14-710b867e4a62)
### Change space security level message
![Screenshot 2025-02-21 at 09 37 46](https://github.com/user-attachments/assets/b4d0213d-a15f-4b17-823c-b6d5353582fe)
